### PR TITLE
Add MCP server + hosted query API + Skill for AI-native paper search

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.db
+**/*.db-shm
+**/*.db-wal
+**/.venv/
+**/*.egg-info/
+.DS_Store
+tools/img/
+tools/mcp-server/.venv/
+tools/query-api/.venv/
+filtered_results-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ papers.db-shm
 tools/query-api/papers.db*
 tools/query-api/.venv/
 tools/mcp-server/.venv/
+tools/query-api/uv.lock
+tools/mcp-server/uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,11 @@ Thumbs.db
 filtered_results-*.json 
 
 *.csv
+
+# Paperlists query-api artifacts (built locally, never committed)
+papers.db
+papers.db-wal
+papers.db-shm
+tools/query-api/papers.db*
+tools/query-api/.venv/
+tools/mcp-server/.venv/

--- a/tools/PR_MESSAGE_MCP.md
+++ b/tools/PR_MESSAGE_MCP.md
@@ -88,7 +88,7 @@ the user asks evolution-shaped questions.
   malformed expressions.
 - Production keeps **4 Uvicorn workers**. Rate-limit state is sqlite-backed in
   a separate writable DB, so all workers share one bucket per IP.
-- Regression suite: **32 tests passing**, plus live smoke tests against the
+- Regression suite: **37 tests passing**, plus live smoke tests against the
   Railway demo.
 
 ## Deployment plan (egress + sustainability)
@@ -97,17 +97,22 @@ Two things to flag honestly:
 
 **Hosting**: A live Railway demo is running at
 `https://api-production-18d3.up.railway.app` under my account
-(env-var-driven; nothing repo-private). The MCP/Skill default to that URL but
-anyone can point at their own instance via `PAPERLISTS_API_URL`. If you'd rather
-it live on `papercopilot` infra (Railway, HF Spaces under `papercopilot` org,
-your own server), I'm happy to hand it over or co-administer — no strings attached.
+(env-var-driven; nothing repo-private). The MCP/Skill require
+`PAPERLISTS_API_URL`; examples can point at the demo, while a release should
+point at `papercopilot` infra (Railway, HF Spaces under `papercopilot` org, your
+own server, etc.). I'm happy to hand it over or co-administer — no strings attached.
 
 **Egress / cost control**:
 - `include_abstract` defaults to `false` on `/v1/search`; abstracts only go out through `/v1/paper/{conf}/{id}` (one-at-a-time).
 - Cross-worker token-bucket rate limiter at 60 req/min/IP (configurable),
   stored in a separate sqlite WAL DB so multi-worker deployments do not multiply
   the effective limit.
-- If traffic grows beyond the free tier, the same Dockerfile redeploys to **Cloudflare Workers + D1** (near-zero idle cost) or **HF Spaces** (free, ML-community-native). No code changes required, only the DB driver.
+- Broad analysis endpoints count matches before aggregating and fail closed with
+  `too_many_matches` above 50k rows; search pagination caps `offset` at 10k.
+- If traffic grows beyond the free tier, the same Dockerfile can redeploy to
+  container hosts such as **HF Spaces**. **Cloudflare Workers + D1** remains a
+  plausible near-zero-idle-cost future port, but it would be a port rather than
+  a DB-driver-only swap.
 
 ## What's intentionally NOT in this PR
 

--- a/tools/PR_MESSAGE_MCP.md
+++ b/tools/PR_MESSAGE_MCP.md
@@ -76,25 +76,37 @@ the user asks evolution-shaped questions.
 
 ## What I've already verified (locally)
 
-- Index builds in **~30s** from the 293 JSON files; final DB **~578 MB**.
-- 218k papers (after `(conf, year, paper_id)` dedup) indexed across 30 conferences.
+- Index builds successfully from the current JSON corpus; the Railway build
+  indexed **237,735 papers** from **292 files** into a **~623 MB** sqlite DB.
 - All endpoints return real, well-shaped data. A couple of examples:
   - `topic_trend("diffusion model", 2018, 2024)` → 17 → 17 → 22 → 58 → 131 → **739** → **2401** papers/year (matches the well-known explosion).
   - `topic_evolution("in-context learning", 2020, 2024, window=2)` → top keywords drift from `deep learning / reinforcement learning` (2020-21) to `in-context learning / large language models` (2022+); venue mix shifts ICLR/NeurIPS → +EMNLP.
   - `compare_periods("vision transformer", 2018-2020 vs 2022-2024)` → 111 → 2112 papers; `vision transformer` itself surfaces as the dominant emerged keyword.
   - `author_trajectory("Yann LeCun", year_from=2018)` → 91 papers across years with correct landmark works.
-- Sqlite FTS5 query sanitization handles hyphens and special chars (e.g. `"in-context learning"` works without breaking FTS syntax).
-- Rate limiter (token bucket, default 60 req/min/IP) tested with a burst.
+- Sqlite FTS5 defaults are safe: ordinary queries are tokenized/quoted, while
+  `raw=true` explicitly opts into full FTS5 syntax and returns HTTP 400 for
+  malformed expressions.
+- Production keeps **4 Uvicorn workers**. Rate-limit state is sqlite-backed in
+  a separate writable DB, so all workers share one bucket per IP.
+- Regression suite: **32 tests passing**, plus live smoke tests against the
+  Railway demo.
 
 ## Deployment plan (egress + sustainability)
 
 Two things to flag honestly:
 
-**Hosting**: I'll deploy a demo to **Railway** under my account (env-var-driven; nothing repo-private). The MCP/Skill default to that URL but anyone can point at their own instance via `PAPERLISTS_API_URL`. If you'd rather it live on `papercopilot` infra (Railway, HF Spaces under `papercopilot` org, your own server), I'm happy to hand it over or co-administer — no strings attached.
+**Hosting**: A live Railway demo is running at
+`https://api-production-18d3.up.railway.app` under my account
+(env-var-driven; nothing repo-private). The MCP/Skill default to that URL but
+anyone can point at their own instance via `PAPERLISTS_API_URL`. If you'd rather
+it live on `papercopilot` infra (Railway, HF Spaces under `papercopilot` org,
+your own server), I'm happy to hand it over or co-administer — no strings attached.
 
 **Egress / cost control**:
 - `include_abstract` defaults to `false` on `/v1/search`; abstracts only go out through `/v1/paper/{conf}/{id}` (one-at-a-time).
-- Token-bucket rate limiter at 60 req/min/IP (configurable).
+- Cross-worker token-bucket rate limiter at 60 req/min/IP (configurable),
+  stored in a separate sqlite WAL DB so multi-worker deployments do not multiply
+  the effective limit.
 - If traffic grows beyond the free tier, the same Dockerfile redeploys to **Cloudflare Workers + D1** (near-zero idle cost) or **HF Spaces** (free, ML-community-native). No code changes required, only the DB driver.
 
 ## What's intentionally NOT in this PR
@@ -107,9 +119,10 @@ Two things to flag honestly:
 ## What I'm asking before merge
 
 1. **Location**: is `tools/{query-api,mcp-server,skill}/` the right home, or
-   would you prefer a separate repo under `papercopilot/`? (e.g.
-   `papercopilot/paperlists-mcp`)
-2. **Naming**: `paperlists-mcp` vs `papercopilot-mcp` — your call.
+   would you prefer a separate repo under `papercopilot/`? I think
+   `papercopilot/paperlists-agent` is the cleanest fit if we split it out.
+2. **Naming**: `paperlists-agent` vs `paperlists-mcp` vs
+   `papercopilot-mcp` — your call.
 3. **Hosting ownership**: happy to host the demo myself for v1; happy to
    hand it to you once it stabilizes. Whichever you prefer.
 4. **API surface**: anything missing? `aff_*` fields are the obvious one I

--- a/tools/PR_MESSAGE_MCP.md
+++ b/tools/PR_MESSAGE_MCP.md
@@ -1,0 +1,121 @@
+# Proposal + implementation: MCP-native query layer for paperlists
+
+Hi @jingyangcarl 👋 — long time no see. I'm the contributor of #7 (the
+Streamlit local search tool). Two threads of context before the proposal:
+
+1. Thank you again for the back-and-forth during my junior research days —
+   that conversation shaped how I think about open data infra.
+2. I've since started a few research projects of my own, and this dataset
+   has been the single most useful conference-paper resource I keep coming
+   back to. The cross-venue, multi-year, review-score coverage is genuinely
+   hard to find elsewhere.
+
+## Motivation
+
+In the year since #7 landed, the "interface to data" has shifted from
+human-facing UIs to AI-agent-facing tool calls. Spinning up a localhost
+Streamlit each time is strictly worse UX than letting a coding agent
+(Claude Code / Cursor / Codex / Claude Desktop) query the corpus directly.
+I think `paperlists` is ready for a first-class AI-native entry point —
+and as a bonus, this further offloads work from papercopilot.com's web
+search (the same motivation that drove #7).
+
+Plain keyword search is already well served by your website. The killer
+feature of an MCP layer isn't another search box — it's **research
+evolution tracking**: "how did RAG evolve 2020→2025", "what changed in
+vision-transformer research between 2018–2020 and 2022–2024", "state of
+mechanistic interpretability in 2024". These questions are awkward on a
+web UI and natural for an agent. I've built the verbs around that.
+
+## What's in this PR
+
+A three-tier architecture, all under `tools/`. Nothing outside `tools/` is
+touched (zero changes to the data layout):
+
+```
+tools/
+  query-api/        # FastAPI + sqlite FTS5 service (deployable)
+    paperlists_api/
+      indexer.py    # builds papers.db from the JSON files
+      queries.py    # all query primitives (separable, testable)
+      main.py       # FastAPI app with rate limiting + abstract gating
+      db.py         # read-only sqlite connection helper
+    Dockerfile      # multi-stage: builder bakes the index, runtime is lean
+    railway.json    # one-click deploy config
+    pyproject.toml
+    README.md
+  mcp-server/       # thin MCP client, ~5MB install
+    paperlists_mcp/
+      server.py     # 10 MCP tools mapped to the API endpoints
+    pyproject.toml
+    README.md
+  skill/            # cross-tool Skill (Claude Code / Cursor / Codex / ...)
+    paperlists.md   # frontmatter + worked patterns
+    scripts/
+      paperlists.py # stdlib-only CLI client (when MCP isn't configured)
+```
+
+### Endpoints (the trend-focused ones are first-class)
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /v1/topic_trend` | **Yearly paper count + citation-weighted volume** for a query, broken down by venue |
+| `GET /v1/topic_evolution` | **Per-window top co-occurring keywords + landmark papers** — surfaces topic drift |
+| `GET /v1/compare_periods` | **Diff a topic across two year ranges** — emerged / faded / sustained, on keywords/authors/affiliations |
+| `GET /v1/author_trajectory` | A researcher's papers grouped by year |
+| `GET /v1/field_landscape` | Single-year snapshot of a field: top papers, authors, affiliations, keywords |
+| `GET /v1/conference_stats/{conf}/{year}` | Acceptance + rating/citation summary |
+| `GET /v1/top_papers/{conf}/{year}` | Ranked by citation or rating |
+| `GET /v1/search` | Standard FTS5 search |
+| `GET /v1/paper/{conf}/{id}` | Single-record full schema |
+| `GET /v1/coverage` | Self-describing — what venues/years are indexed |
+
+The MCP server exposes the same surface as 10 tools. Tool descriptions
+explicitly steer agents toward `topic_evolution` / `compare_periods` when
+the user asks evolution-shaped questions.
+
+## What I've already verified (locally)
+
+- Index builds in **~30s** from the 293 JSON files; final DB **~578 MB**.
+- 218k papers (after `(conf, year, paper_id)` dedup) indexed across 30 conferences.
+- All endpoints return real, well-shaped data. A couple of examples:
+  - `topic_trend("diffusion model", 2018, 2024)` → 17 → 17 → 22 → 58 → 131 → **739** → **2401** papers/year (matches the well-known explosion).
+  - `topic_evolution("in-context learning", 2020, 2024, window=2)` → top keywords drift from `deep learning / reinforcement learning` (2020-21) to `in-context learning / large language models` (2022+); venue mix shifts ICLR/NeurIPS → +EMNLP.
+  - `compare_periods("vision transformer", 2018-2020 vs 2022-2024)` → 111 → 2112 papers; `vision transformer` itself surfaces as the dominant emerged keyword.
+  - `author_trajectory("Yann LeCun", year_from=2018)` → 91 papers across years with correct landmark works.
+- Sqlite FTS5 query sanitization handles hyphens and special chars (e.g. `"in-context learning"` works without breaking FTS syntax).
+- Rate limiter (token bucket, default 60 req/min/IP) tested with a burst.
+
+## Deployment plan (egress + sustainability)
+
+Two things to flag honestly:
+
+**Hosting**: I'll deploy a demo to **Railway** under my account (env-var-driven; nothing repo-private). The MCP/Skill default to that URL but anyone can point at their own instance via `PAPERLISTS_API_URL`. If you'd rather it live on `papercopilot` infra (Railway, HF Spaces under `papercopilot` org, your own server), I'm happy to hand it over or co-administer — no strings attached.
+
+**Egress / cost control**:
+- `include_abstract` defaults to `false` on `/v1/search`; abstracts only go out through `/v1/paper/{conf}/{id}` (one-at-a-time).
+- Token-bucket rate limiter at 60 req/min/IP (configurable).
+- If traffic grows beyond the free tier, the same Dockerfile redeploys to **Cloudflare Workers + D1** (near-zero idle cost) or **HF Spaces** (free, ML-community-native). No code changes required, only the DB driver.
+
+## What's intentionally NOT in this PR
+
+- No changes to existing data layout (still your `<conf>/<conf><year>.json` layout)
+- No removal of `app.py` or `extract.py` — the Streamlit tool stays
+- No embedding-based / semantic search — deferred; would need a vector DB
+- No affiliation normalization across `aff_unique_norm` variants — left for v2
+
+## What I'm asking before merge
+
+1. **Location**: is `tools/{query-api,mcp-server,skill}/` the right home, or
+   would you prefer a separate repo under `papercopilot/`? (e.g.
+   `papercopilot/paperlists-mcp`)
+2. **Naming**: `paperlists-mcp` vs `papercopilot-mcp` — your call.
+3. **Hosting ownership**: happy to host the demo myself for v1; happy to
+   hand it to you once it stabilizes. Whichever you prefer.
+4. **API surface**: anything missing? `aff_*` fields are the obvious one I
+   underweighted — easy to add if useful.
+
+I tried to keep the diff strictly additive so it's easy to revert if any
+piece doesn't land. Looking forward to your read.
+
+— @hhh2210

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,7 +9,10 @@ Three complementary entry points for working with the paperlists corpus:
 | [`mcp-server/`](mcp-server/) | MCP server for Claude Code / Cursor / Codex / Claude Desktop / any MCP host | You want AI agents to query the corpus directly |
 | [`skill/`](skill/) | Cross-tool Skill (`.md` + bundled CLI script) | You want zero-install access from any LLM that loads skills |
 
-The MCP server and Skill both default to the hosted API, so end users don't need to download the ~830MB of raw JSON. Set `PAPERLISTS_API_URL` to point at a self-hosted instance.
+The MCP server and Skill both default to the hosted API
+(`https://api-production-18d3.up.railway.app`), so end users don't need to
+download the ~830MB of raw JSON. Set `PAPERLISTS_API_URL` to point at a
+self-hosted instance.
 
 # Paper Search Tool (legacy / local Streamlit)
 
@@ -56,4 +59,4 @@ Example:
 ```bash
 cd tools
 python extract.py retrieval -i iclr/iclr2025.json -o results.json -f title keywords
-``` 
+```

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,10 +9,11 @@ Three complementary entry points for working with the paperlists corpus:
 | [`mcp-server/`](mcp-server/) | MCP server for Claude Code / Cursor / Codex / Claude Desktop / any MCP host | You want AI agents to query the corpus directly |
 | [`skill/`](skill/) | Cross-tool Skill (`.md` + bundled CLI script) | You want zero-install access from any LLM that loads skills |
 
-The MCP server and Skill both default to the hosted API
-(`https://api-production-18d3.up.railway.app`), so end users don't need to
-download the ~830MB of raw JSON. Set `PAPERLISTS_API_URL` to point at a
-self-hosted instance.
+The MCP server and Skill use `PAPERLISTS_API_URL` to choose a backend. For
+demo testing, you can point them at the contributor-hosted Railway API
+(`https://api-production-18d3.up.railway.app`) without downloading the ~830MB
+of raw JSON. Production releases should point at papercopilot-owned or
+self-hosted infrastructure.
 
 # Paper Search Tool (legacy / local Streamlit)
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,4 +1,17 @@
-# Paper Search Tool
+# Paperlists Tools
+
+Three complementary entry points for working with the paperlists corpus:
+
+| Directory | What it is | When to use |
+|---|---|---|
+| `app.py` / `extract.py` | Streamlit web UI + CLI (original tools) | You want to manually browse the corpus on your laptop |
+| [`query-api/`](query-api/) | Hosted FastAPI service backed by sqlite FTS5 | You're deploying the service (Railway/HF Spaces) or want a local HTTP layer |
+| [`mcp-server/`](mcp-server/) | MCP server for Claude Code / Cursor / Codex / Claude Desktop / any MCP host | You want AI agents to query the corpus directly |
+| [`skill/`](skill/) | Cross-tool Skill (`.md` + bundled CLI script) | You want zero-install access from any LLM that loads skills |
+
+The MCP server and Skill both default to the hosted API, so end users don't need to download the ~830MB of raw JSON. Set `PAPERLISTS_API_URL` to point at a self-hosted instance.
+
+# Paper Search Tool (legacy / local Streamlit)
 
 A Streamlit-based tool for efficiently searching and analyzing conference papers locally. 
 ## Why This Tool?

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -2,7 +2,9 @@
 
 An MCP (Model Context Protocol) server that exposes the [papercopilot/paperlists](https://github.com/papercopilot/paperlists) corpus to AI agents — Claude Code, Claude Desktop, Cursor, Codex, OpenAI ChatGPT (via MCP), Hermes, anything that speaks MCP.
 
-A thin wrapper around the hosted [`paperlists-api`](../query-api/) service: zero data download, zero local index. ~5 MB install footprint.
+A thin wrapper around any hosted [`paperlists-api`](../query-api/) service:
+zero data download, zero local index. ~5 MB install footprint. Set
+`PAPERLISTS_API_URL` to a papercopilot-owned, self-hosted, or demo API endpoint.
 
 ## Why MCP?
 
@@ -16,6 +18,9 @@ pip install -e .
 # or:
 uvx --from . paperlists-mcp
 ```
+
+`PAPERLISTS_API_URL` is required at runtime. For demo testing only, use
+`https://api-production-18d3.up.railway.app`.
 
 ## Register with your MCP client
 

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -1,0 +1,68 @@
+# paperlists-mcp
+
+An MCP (Model Context Protocol) server that exposes the [papercopilot/paperlists](https://github.com/papercopilot/paperlists) corpus to AI agents — Claude Code, Claude Desktop, Cursor, Codex, OpenAI ChatGPT (via MCP), Hermes, anything that speaks MCP.
+
+A thin wrapper around the hosted [`paperlists-api`](../query-api/) service: zero data download, zero local index. ~5 MB install footprint.
+
+## Why MCP?
+
+`papercopilot.com` already answers "find me this paper". The MCP server is built around the harder question agents actually ask: **how has this research area evolved?** Tools like `topic_trend`, `topic_evolution`, `compare_periods`, and `field_landscape` are first-class — they answer questions that would otherwise require dozens of manual searches.
+
+## Install
+
+```bash
+# from this directory
+pip install -e .
+# or:
+uvx --from . paperlists-mcp
+```
+
+## Register with your MCP client
+
+### Claude Code / Claude Desktop
+Add to `~/.config/claude/claude_desktop_config.json` (or use `claude mcp add`):
+
+```jsonc
+{
+  "mcpServers": {
+    "paperlists": {
+      "command": "uvx",
+      "args": ["paperlists-mcp"],
+      "env": {
+        "PAPERLISTS_API_URL": "https://paperlists.up.railway.app"
+      }
+    }
+  }
+}
+```
+
+### Cursor / Codex / others
+Same `command` + `args`. Cursor reads `~/.cursor/mcp.json`; Codex reads `~/.codex/mcp.json` (key names vary slightly across hosts but the launch command is identical).
+
+## Tools
+
+| Tool | What it answers |
+|---|---|
+| `list_coverage` | What venues/years are indexed |
+| `search_papers` | Plain FTS5 search across title/abstract/keywords/authors |
+| `get_paper` | Fetch a single paper's full record (including abstract) |
+| **`topic_trend`** | Yearly volume + citation-weight for a research area |
+| **`topic_evolution`** | Per-window top keywords / venues / landmark papers — surfaces topic drift |
+| **`compare_periods`** | Diff a topic across two year ranges: emerged / faded / sustained |
+| `author_trajectory` | A researcher's papers grouped by year |
+| `field_landscape` | Single-year snapshot of a field |
+| `conference_stats` | Acceptance + rating/citation distribution |
+| `top_papers` | Ranked by citation or rating |
+
+## Running against a local index
+
+If you have the paperlists repo cloned and want to avoid the hosted API entirely (offline use, very large queries, custom modifications):
+
+```bash
+# in tools/query-api/
+python -m paperlists_api.indexer ../.. papers.db
+PAPERLISTS_DB=$PWD/papers.db uvicorn paperlists_api.main:app --port 8000 &
+PAPERLISTS_API_URL=http://localhost:8000 paperlists-mcp
+```
+
+The MCP server's contract is identical against either backend.

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -29,7 +29,7 @@ Add to `~/.config/claude/claude_desktop_config.json` (or use `claude mcp add`):
       "command": "uvx",
       "args": ["paperlists-mcp"],
       "env": {
-        "PAPERLISTS_API_URL": "https://paperlists.up.railway.app"
+        "PAPERLISTS_API_URL": "https://api-production-18d3.up.railway.app"
       }
     }
   }
@@ -54,6 +54,10 @@ Same `command` + `args`. Cursor reads `~/.cursor/mcp.json`; Codex reads `~/.code
 | `conference_stats` | Acceptance + rating/citation distribution |
 | `top_papers` | Ranked by citation or rating |
 
+`search_papers` and the trend-style tools default to `exclude_rejected=true`.
+Use `exclude_rejected=false` only for raw corpus diagnostics. Topic tools also
+accept comma-separated `conferences` filters such as `iclr,nips,icml`.
+
 ## Running against a local index
 
 If you have the paperlists repo cloned and want to avoid the hosted API entirely (offline use, very large queries, custom modifications):
@@ -66,3 +70,9 @@ PAPERLISTS_API_URL=http://localhost:8000 paperlists-mcp
 ```
 
 The MCP server's contract is identical against either backend.
+The same local API override also works for the bundled Skill:
+
+```bash
+cd ../skill
+PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py coverage
+```

--- a/tools/mcp-server/paperlists_mcp/__init__.py
+++ b/tools/mcp-server/paperlists_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Paperlists MCP server — exposes the paperlists query API as MCP tools."""
+
+__version__ = "0.1.0"

--- a/tools/mcp-server/paperlists_mcp/server.py
+++ b/tools/mcp-server/paperlists_mcp/server.py
@@ -1,0 +1,222 @@
+"""MCP server for the papercopilot/paperlists corpus.
+
+Defaults to talking to the hosted demo API; can be pointed at any deployment
+via PAPERLISTS_API_URL. Designed as a thin client so the same code works
+across Claude Code / Claude Desktop / Cursor / Codex / any MCP host.
+
+Run via stdio:
+    uvx --from . paperlists-mcp
+    # or
+    python -m paperlists_mcp.server
+
+Env vars:
+    PAPERLISTS_API_URL   default: https://paperlists.up.railway.app
+    PAPERLISTS_TIMEOUT   default: 30 (seconds)
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+API_URL = os.environ.get("PAPERLISTS_API_URL", "https://paperlists.up.railway.app").rstrip("/")
+TIMEOUT = float(os.environ.get("PAPERLISTS_TIMEOUT", "30"))
+
+mcp = FastMCP("paperlists")
+_client = httpx.Client(base_url=API_URL, timeout=TIMEOUT, headers={"User-Agent": "paperlists-mcp/0.1"})
+
+
+def _get(path: str, **params) -> dict:
+    # Drop None params so they don't override defaults on the server side.
+    clean = {k: v for k, v in params.items() if v is not None}
+    resp = _client.get(path, params=clean)
+    if resp.status_code >= 400:
+        return {"error": f"HTTP {resp.status_code}", "detail": resp.text[:500]}
+    return resp.json()
+
+
+@mcp.tool()
+def list_coverage() -> dict:
+    """List which conferences and years are indexed.
+
+    Returns total paper count and a per-conference breakdown. Always call this
+    first if you're unsure whether a venue/year is available — it costs no
+    quota and saves wasted searches.
+    """
+    return _get("/v1/coverage")
+
+
+@mcp.tool()
+def search_papers(
+    query: str,
+    conferences: Optional[str] = None,
+    year_from: Optional[int] = None,
+    year_to: Optional[int] = None,
+    exclude_rejected: bool = True,
+    limit: int = 25,
+    order_by: str = "relevance",
+    include_abstract: bool = False,
+) -> dict:
+    """Full-text search over title / abstract / keywords / authors.
+
+    Args:
+        query: Free-text query. Multi-word terms are AND'd. FTS5 syntax works
+            ("foo OR bar", "\"exact phrase\"").
+        conferences: Comma-separated venue list (e.g. "iclr,nips,icml").
+            Omit to search all.
+        year_from / year_to: Inclusive year filter.
+        exclude_rejected: Drop Reject/Withdraw entries (recommended).
+        limit: Max results (1-200).
+        order_by: "relevance" | "year_desc" | "citation_desc" | "rating_desc".
+        include_abstract: Set true only if you need full abstracts — they
+            cost ~1KB per result.
+    """
+    return _get(
+        "/v1/search",
+        q=query, conferences=conferences,
+        year_from=year_from, year_to=year_to,
+        exclude_rejected=exclude_rejected,
+        limit=limit, order_by=order_by,
+        include_abstract=include_abstract,
+    )
+
+
+@mcp.tool()
+def get_paper(conf: str, paper_id: str) -> dict:
+    """Fetch a single paper's full record including abstract and affiliations.
+
+    Args:
+        conf: Lowercase venue (e.g. "iclr", "nips").
+        paper_id: The paper's `id` field from the JSON (OpenReview ID, etc.).
+    """
+    return _get(f"/v1/paper/{conf}/{paper_id}")
+
+
+@mcp.tool()
+def topic_trend(
+    query: str,
+    conferences: Optional[str] = None,
+    year_from: Optional[int] = None,
+    year_to: Optional[int] = None,
+) -> dict:
+    """Yearly publication volume + citation-weighted volume for a topic.
+
+    Use this to see how a research area has grown or declined over time.
+    Returns a `series` of `{year, papers, citations, by_conf}` records.
+
+    Example queries: "diffusion model", "retrieval augmented generation",
+    "mixture of experts", "constitutional AI".
+    """
+    return _get(
+        "/v1/topic_trend",
+        q=query, conferences=conferences,
+        year_from=year_from, year_to=year_to,
+    )
+
+
+@mcp.tool()
+def topic_evolution(
+    query: str,
+    year_from: int,
+    year_to: int,
+    window: int = 1,
+    top_k: int = 15,
+    conferences: Optional[str] = None,
+) -> dict:
+    """Track how a research area evolves: per-window top co-occurring keywords,
+    top venues, and landmark (highest-cited) papers.
+
+    This is the single best tool for answering "how did <field> change between
+    year X and year Y?" It surfaces topic drift inside a query — e.g. asking
+    `topic_evolution("retrieval augmented generation", 2020, 2024, window=1)`
+    will show RAG morphing from dense-passage-retrieval era into LLM-coupled
+    pipelines.
+
+    Args:
+        window: years per bucket (1 = annual, 2 = biennial, ...).
+        top_k: keywords/venues per window.
+    """
+    return _get(
+        "/v1/topic_evolution",
+        q=query, year_from=year_from, year_to=year_to,
+        window=window, top_k=top_k, conferences=conferences,
+    )
+
+
+@mcp.tool()
+def compare_periods(
+    query: str,
+    period_a_from: int,
+    period_a_to: int,
+    period_b_from: int,
+    period_b_to: int,
+    top_k: int = 15,
+) -> dict:
+    """Diff a topic between two year ranges. Returns three buckets per
+    dimension (keywords, authors, affiliations):
+
+    - **emerged**: present in period B but not period A
+    - **faded**: present in period A but not period B
+    - **sustained**: present in both, sorted by total volume
+
+    Use when you have a hypothesis like "RLHF moved from RL conferences to
+    NLP conferences between 2022 and 2024" — this tool will confirm or refute.
+    """
+    return _get(
+        "/v1/compare_periods",
+        q=query,
+        period_a_from=period_a_from, period_a_to=period_a_to,
+        period_b_from=period_b_from, period_b_to=period_b_to,
+        top_k=top_k,
+    )
+
+
+@mcp.tool()
+def author_trajectory(
+    name: str,
+    year_from: Optional[int] = None,
+    year_to: Optional[int] = None,
+) -> dict:
+    """Papers by an author across years, useful for tracking a researcher's
+    topical pivots or productivity. Match is on the `authors` field — use
+    the canonical name as it appears in publications.
+    """
+    return _get(
+        "/v1/author_trajectory",
+        name=name, year_from=year_from, year_to=year_to,
+    )
+
+
+@mcp.tool()
+def field_landscape(query: str, year: int, top_k: int = 10) -> dict:
+    """Snapshot a research field in a specific year: top papers (by citation),
+    top authors, top affiliations, top keywords, venue distribution.
+
+    Use for "state of <field> in <year>" summaries or to identify the dominant
+    labs in a subfield at a point in time.
+    """
+    return _get("/v1/field_landscape", q=query, year=year, top_k=top_k)
+
+
+@mcp.tool()
+def conference_stats(conf: str, year: int) -> dict:
+    """Acceptance breakdown + rating/citation distribution for a single
+    venue-year. Useful for "how selective was ICLR 2024?" type questions."""
+    return _get(f"/v1/conference_stats/{conf}/{year}")
+
+
+@mcp.tool()
+def top_papers(conf: str, year: int, by: str = "gs_citation", top_k: int = 20) -> dict:
+    """Top-N papers from a single venue-year, ranked by `gs_citation` or
+    `rating`. Returns title, authors, paper_id, URLs."""
+    return _get(f"/v1/top_papers/{conf}/{year}", by=by, top_k=top_k)
+
+
+def main():
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mcp-server/paperlists_mcp/server.py
+++ b/tools/mcp-server/paperlists_mcp/server.py
@@ -10,18 +10,19 @@ Run via stdio:
     python -m paperlists_mcp.server
 
 Env vars:
-    PAPERLISTS_API_URL   default: https://paperlists.up.railway.app
+    PAPERLISTS_API_URL   default: https://api-production-18d3.up.railway.app
     PAPERLISTS_TIMEOUT   default: 30 (seconds)
 """
 from __future__ import annotations
 
 import os
+from urllib.parse import quote
 from typing import Optional
 
 import httpx
 from mcp.server.fastmcp import FastMCP
 
-API_URL = os.environ.get("PAPERLISTS_API_URL", "https://paperlists.up.railway.app").rstrip("/")
+API_URL = os.environ.get("PAPERLISTS_API_URL", "https://api-production-18d3.up.railway.app").rstrip("/")
 TIMEOUT = float(os.environ.get("PAPERLISTS_TIMEOUT", "30"))
 
 mcp = FastMCP("paperlists")
@@ -31,9 +32,17 @@ _client = httpx.Client(base_url=API_URL, timeout=TIMEOUT, headers={"User-Agent":
 def _get(path: str, **params) -> dict:
     # Drop None params so they don't override defaults on the server side.
     clean = {k: v for k, v in params.items() if v is not None}
-    resp = _client.get(path, params=clean)
+    try:
+        resp = _client.get(path, params=clean)
+    except httpx.HTTPError as e:
+        return {"error": "network_error", "detail": str(e)}
     if resp.status_code >= 400:
-        return {"error": f"HTTP {resp.status_code}", "detail": resp.text[:500]}
+        # Surface the API's structured error (e.g. invalid_query) when present.
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {"detail": resp.text[:500]}
+        return {"error": body.get("error", f"HTTP {resp.status_code}"), **body}
     return resp.json()
 
 
@@ -56,30 +65,44 @@ def search_papers(
     year_to: Optional[int] = None,
     exclude_rejected: bool = True,
     limit: int = 25,
+    offset: int = 0,
     order_by: str = "relevance",
     include_abstract: bool = False,
+    raw: bool = False,
 ) -> dict:
     """Full-text search over title / abstract / keywords / authors.
 
     Args:
-        query: Free-text query. Multi-word terms are AND'd. FTS5 syntax works
-            ("foo OR bar", "\"exact phrase\"").
+        query: Free-text query. By default, input is split into terms and
+            AND'd together (safe for arbitrary user input). To use FTS5
+            operators (`foo OR bar`, `"exact phrase"`, `title:diffusion`,
+            `reason*`), set `raw=True`.
         conferences: Comma-separated venue list (e.g. "iclr,nips,icml").
             Omit to search all.
         year_from / year_to: Inclusive year filter.
         exclude_rejected: Drop Reject/Withdraw entries (recommended).
         limit: Max results (1-200).
+        offset: Pagination offset. Combine with `has_more` in the response
+            to walk through long result sets — call again with
+            `offset = previous_offset + previous_limit` until `has_more` is
+            false.
         order_by: "relevance" | "year_desc" | "citation_desc" | "rating_desc".
         include_abstract: Set true only if you need full abstracts — they
             cost ~1KB per result.
+        raw: Enable full FTS5 syntax. Malformed expressions return HTTP 400
+            (surfaced as `{error: "invalid_query"}` in the result).
+
+    Returns a dict with `total_matches`, `returned`, `offset`, `limit`,
+    `has_more`, and `results`. Use `has_more` to paginate.
     """
     return _get(
         "/v1/search",
         q=query, conferences=conferences,
         year_from=year_from, year_to=year_to,
         exclude_rejected=exclude_rejected,
-        limit=limit, order_by=order_by,
+        limit=limit, offset=offset, order_by=order_by,
         include_abstract=include_abstract,
+        raw=raw,
     )
 
 
@@ -91,7 +114,7 @@ def get_paper(conf: str, paper_id: str) -> dict:
         conf: Lowercase venue (e.g. "iclr", "nips").
         paper_id: The paper's `id` field from the JSON (OpenReview ID, etc.).
     """
-    return _get(f"/v1/paper/{conf}/{paper_id}")
+    return _get(f"/v1/paper/{quote(conf, safe='')}/{quote(paper_id, safe='')}")
 
 
 @mcp.tool()
@@ -100,6 +123,8 @@ def topic_trend(
     conferences: Optional[str] = None,
     year_from: Optional[int] = None,
     year_to: Optional[int] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
     """Yearly publication volume + citation-weighted volume for a topic.
 
@@ -107,12 +132,14 @@ def topic_trend(
     Returns a `series` of `{year, papers, citations, by_conf}` records.
 
     Example queries: "diffusion model", "retrieval augmented generation",
-    "mixture of experts", "constitutional AI".
+    "mixture of experts", "constitutional AI". Set `raw=True` for FTS5
+    operator support.
     """
     return _get(
         "/v1/topic_trend",
         q=query, conferences=conferences,
         year_from=year_from, year_to=year_to,
+        exclude_rejected=exclude_rejected, raw=raw,
     )
 
 
@@ -124,9 +151,11 @@ def topic_evolution(
     window: int = 1,
     top_k: int = 15,
     conferences: Optional[str] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
     """Track how a research area evolves: per-window top co-occurring keywords,
-    top venues, and landmark (highest-cited) papers.
+    top venues, and landmark papers.
 
     This is the single best tool for answering "how did <field> change between
     year X and year Y?" It surfaces topic drift inside a query — e.g. asking
@@ -134,14 +163,23 @@ def topic_evolution(
     will show RAG morphing from dense-passage-retrieval era into LLM-coupled
     pipelines.
 
+    Each window includes a `ranking_basis` field — `"gs_citation"` when
+    citations are meaningful, `"rating_avg+status_fallback"` for the current
+    year where citations are near-zero. In the fallback regime, landmarks
+    are sorted by acceptance status (Oral > Spotlight > Poster) and rating,
+    not citations.
+
     Args:
         window: years per bucket (1 = annual, 2 = biennial, ...).
         top_k: keywords/venues per window.
+        exclude_rejected: Drop Reject/Withdraw entries (recommended).
+        raw: Enable full FTS5 syntax in the query.
     """
     return _get(
         "/v1/topic_evolution",
         q=query, year_from=year_from, year_to=year_to,
         window=window, top_k=top_k, conferences=conferences,
+        exclude_rejected=exclude_rejected, raw=raw,
     )
 
 
@@ -153,6 +191,9 @@ def compare_periods(
     period_b_from: int,
     period_b_to: int,
     top_k: int = 15,
+    conferences: Optional[str] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
     """Diff a topic between two year ranges. Returns three buckets per
     dimension (keywords, authors, affiliations):
@@ -163,6 +204,9 @@ def compare_periods(
 
     Use when you have a hypothesis like "RLHF moved from RL conferences to
     NLP conferences between 2022 and 2024" — this tool will confirm or refute.
+
+    Each period in the response exposes both `years: [a, b]` and flat
+    `year_from`/`year_to` fields. Set `raw=True` for FTS5 operator support.
     """
     return _get(
         "/v1/compare_periods",
@@ -170,6 +214,8 @@ def compare_periods(
         period_a_from=period_a_from, period_a_to=period_a_to,
         period_b_from=period_b_from, period_b_to=period_b_to,
         top_k=top_k,
+        conferences=conferences,
+        exclude_rejected=exclude_rejected, raw=raw,
     )
 
 
@@ -190,14 +236,25 @@ def author_trajectory(
 
 
 @mcp.tool()
-def field_landscape(query: str, year: int, top_k: int = 10) -> dict:
+def field_landscape(
+    query: str,
+    year: int,
+    top_k: int = 10,
+    conferences: Optional[str] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
+) -> dict:
     """Snapshot a research field in a specific year: top papers (by citation),
     top authors, top affiliations, top keywords, venue distribution.
 
     Use for "state of <field> in <year>" summaries or to identify the dominant
-    labs in a subfield at a point in time.
+    labs in a subfield at a point in time. `raw=True` enables FTS5 operators.
     """
-    return _get("/v1/field_landscape", q=query, year=year, top_k=top_k)
+    return _get(
+        "/v1/field_landscape",
+        q=query, year=year, top_k=top_k,
+        conferences=conferences, exclude_rejected=exclude_rejected, raw=raw,
+    )
 
 
 @mcp.tool()
@@ -208,10 +265,23 @@ def conference_stats(conf: str, year: int) -> dict:
 
 
 @mcp.tool()
-def top_papers(conf: str, year: int, by: str = "gs_citation", top_k: int = 20) -> dict:
+def top_papers(
+    conf: str, year: int,
+    by: str = "gs_citation",
+    top_k: int = 20,
+    exclude_rejected: bool = True,
+) -> dict:
     """Top-N papers from a single venue-year, ranked by `gs_citation` or
-    `rating`. Returns title, authors, paper_id, URLs."""
-    return _get(f"/v1/top_papers/{conf}/{year}", by=by, top_k=top_k)
+    `rating`. Returns title, authors, paper_id, URLs.
+
+    `exclude_rejected` defaults to True so Reject/Withdraw entries don't
+    pollute the ranking on OpenReview venues (ICLR/ICML/COLM). Set False
+    for raw corpus diagnostics.
+    """
+    return _get(
+        f"/v1/top_papers/{conf}/{year}",
+        by=by, top_k=top_k, exclude_rejected=exclude_rejected,
+    )
 
 
 def main():

--- a/tools/mcp-server/paperlists_mcp/server.py
+++ b/tools/mcp-server/paperlists_mcp/server.py
@@ -1,7 +1,9 @@
 """MCP server for the papercopilot/paperlists corpus.
 
-Defaults to talking to the hosted demo API; can be pointed at any deployment
-via PAPERLISTS_API_URL. Designed as a thin client so the same code works
+Talks to any paperlists API deployment via PAPERLISTS_API_URL. A contributor-
+hosted demo exists for evaluation, but the server does not silently default to
+it so upstream users do not send queries to non-papercopilot infrastructure by
+accident. Designed as a thin client so the same code works
 across Claude Code / Claude Desktop / Cursor / Codex / any MCP host.
 
 Run via stdio:
@@ -10,7 +12,7 @@ Run via stdio:
     python -m paperlists_mcp.server
 
 Env vars:
-    PAPERLISTS_API_URL   default: https://api-production-18d3.up.railway.app
+    PAPERLISTS_API_URL   required; demo: https://api-production-18d3.up.railway.app
     PAPERLISTS_TIMEOUT   default: 30 (seconds)
 """
 from __future__ import annotations
@@ -22,14 +24,26 @@ from typing import Optional
 import httpx
 from mcp.server.fastmcp import FastMCP
 
-API_URL = os.environ.get("PAPERLISTS_API_URL", "https://api-production-18d3.up.railway.app").rstrip("/")
+DEMO_API_URL = "https://api-production-18d3.up.railway.app"
+API_URL = os.environ.get("PAPERLISTS_API_URL", "").rstrip("/")
 TIMEOUT = float(os.environ.get("PAPERLISTS_TIMEOUT", "30"))
 
 mcp = FastMCP("paperlists")
-_client = httpx.Client(base_url=API_URL, timeout=TIMEOUT, headers={"User-Agent": "paperlists-mcp/0.1"})
+_client = (
+    httpx.Client(base_url=API_URL, timeout=TIMEOUT, headers={"User-Agent": "paperlists-mcp/0.1"})
+    if API_URL else None
+)
 
 
 def _get(path: str, **params) -> dict:
+    if _client is None:
+        return {
+            "error": "missing_api_url",
+            "detail": (
+                "Set PAPERLISTS_API_URL to a paperlists API deployment. "
+                f"For demo testing only, use {DEMO_API_URL}."
+            ),
+        }
     # Drop None params so they don't override defaults on the server side.
     clean = {k: v for k, v in params.items() if v is not None}
     try:

--- a/tools/mcp-server/pyproject.toml
+++ b/tools/mcp-server/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "paperlists-mcp"
+version = "0.1.0"
+description = "MCP server exposing the papercopilot/paperlists corpus to AI agents."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp[cli]>=1.0",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+paperlists-mcp = "paperlists_mcp.server:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["paperlists_mcp*"]

--- a/tools/query-api/.dockerignore
+++ b/tools/query-api/.dockerignore
@@ -1,0 +1,12 @@
+**/__pycache__
+**/*.pyc
+.git
+.gitignore
+tools/img
+tools/mcp-server
+tools/skill
+tools/PR_MESSAGE.md
+tools/app.py
+*.db
+*.db-wal
+*.db-shm

--- a/tools/query-api/.gitignore
+++ b/tools/query-api/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+papers.db
+papers.db-shm
+papers.db-wal

--- a/tools/query-api/Dockerfile
+++ b/tools/query-api/Dockerfile
@@ -1,0 +1,36 @@
+# --- Stage 1: build sqlite FTS5 index from the JSON corpus ---
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+RUN pip install --no-cache-dir orjson
+
+# Build context is the repo root (set in railway.json).
+# Copy only what we need to keep image small.
+COPY tools/query-api/paperlists_api ./paperlists_api
+COPY 3dv aaai acl acml aistats alt automl coling colm colt corl cvpr \
+     eccv emnlp iccv iclr icml icra ijcai iros kdd naacl nips rss \
+     siggraph siggraphasia uai wacv www \
+     /data/
+
+# ai4x is optional / future; tolerate it being absent.
+RUN if [ -d /data/ai4x ]; then echo "ai4x present"; fi
+
+RUN python -m paperlists_api.indexer /data /build/papers.db && \
+    sqlite3 /build/papers.db "VACUUM;" 2>/dev/null || true && \
+    ls -lh /build/papers.db
+
+# --- Stage 2: lean runtime ---
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1 \
+    PAPERLISTS_DB=/app/papers.db
+
+COPY tools/query-api/pyproject.toml ./pyproject.toml
+COPY tools/query-api/paperlists_api ./paperlists_api
+RUN pip install --no-cache-dir .
+
+COPY --from=builder /build/papers.db /app/papers.db
+
+EXPOSE 8000
+CMD ["uvicorn", "paperlists_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tools/query-api/Dockerfile
+++ b/tools/query-api/Dockerfile
@@ -2,21 +2,36 @@
 FROM python:3.11-slim AS builder
 
 WORKDIR /build
+ARG PAPERLISTS_DATA_REF=main
 RUN pip install --no-cache-dir orjson
 
-# Build context is the repo root (set in railway.json).
-# Copy only what we need to keep image small.
-COPY tools/query-api/paperlists_api ./paperlists_api
-COPY 3dv aaai acl acml aistats alt automl coling colm colt corl cvpr \
-     eccv emnlp iccv iclr icml icra ijcai iros kdd naacl nips rss \
-     siggraph siggraphasia uai wacv www \
-     /data/
+COPY paperlists_api ./paperlists_api
 
-# ai4x is optional / future; tolerate it being absent.
-RUN if [ -d /data/ai4x ]; then echo "ai4x present"; fi
+# Railway CLI uploads only this tools/query-api directory. Fetch the paperlists
+# JSON corpus inside the builder to avoid sending hundreds of MB through the
+# deployment upload path.
+RUN python - <<'PY' "$PAPERLISTS_DATA_REF"
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+ref = sys.argv[1]
+archive = Path("/tmp/paperlists.tar.gz")
+url = f"https://github.com/papercopilot/paperlists/archive/refs/heads/{ref}.tar.gz"
+urllib.request.urlretrieve(url, archive)
+with tarfile.open(archive, "r:gz") as tar:
+    tar.extractall("/tmp")
+src = next(Path("/tmp").glob("paperlists-*"))
+for child in src.iterdir():
+    if child.is_dir() and not child.name.startswith(".") and child.name != "tools":
+        target = Path("/data") / child.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        child.rename(target)
+PY
 
 RUN python -m paperlists_api.indexer /data /build/papers.db && \
-    sqlite3 /build/papers.db "VACUUM;" 2>/dev/null || true && \
+    python -c "import sqlite3; c=sqlite3.connect('/build/papers.db'); c.execute('VACUUM'); c.close()" && \
     ls -lh /build/papers.db
 
 # --- Stage 2: lean runtime ---
@@ -24,10 +39,14 @@ FROM python:3.11-slim
 
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 \
-    PAPERLISTS_DB=/app/papers.db
+    PAPERLISTS_DB=/app/papers.db \
+    PAPERLISTS_DB_IMMUTABLE=1 \
+    PAPERLISTS_DB_CACHE_KIB=65536 \
+    PAPERLISTS_DB_MMAP_BYTES=536870912 \
+    WEB_CONCURRENCY=4
 
-COPY tools/query-api/pyproject.toml ./pyproject.toml
-COPY tools/query-api/paperlists_api ./paperlists_api
+COPY pyproject.toml ./pyproject.toml
+COPY paperlists_api ./paperlists_api
 RUN pip install --no-cache-dir .
 
 COPY --from=builder /build/papers.db /app/papers.db

--- a/tools/query-api/README.md
+++ b/tools/query-api/README.md
@@ -47,11 +47,15 @@ PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py topic_evo
 ## Deployment
 
 ### Railway
+- Live demo used by the MCP server and Skill defaults:
+  `https://api-production-18d3.up.railway.app`.
 - Use `tools/query-api` as the Railway upload/build root.
 - The Docker build fetches the paperlists JSON corpus from GitHub inside Railway and builds `papers.db` there. This avoids uploading hundreds of MB of tracked JSON through `railway up`.
 - Railway reads `tools/query-api/railway.json` and uses `Dockerfile` from this directory.
 - Runtime defaults to **4 Uvicorn workers** (`WEB_CONCURRENCY=4`). The rate-limit state is sqlite-backed (`paperlists_api/ratelimit.py`, separate writable file at `/tmp/paperlists-ratelimit.db`) so all workers share one bucket per IP. No risk of `N×limit` bypass from sticky worker routing.
 - `PAPERLISTS_TRUST_PROXY` defaults to `"auto"`, which auto-enables XFF-trust whenever a known platform marker is present in the env (Railway / HF Spaces / Fly / Render / Vercel / Cloud Run / Azure App Service). Set it to `"1"` or `"0"` to override. On any host **not** in that list, set `PAPERLISTS_TRUST_PROXY=1` explicitly or every visitor will share one rate-limit bucket because `req.client.host` resolves to the proxy address. Uvicorn is **not** started with `--forwarded-allow-ips=*` — that flag would let uvicorn itself rewrite `request.client.host` from XFF *before* the middleware runs, defeating the trust gate.
+- Current Railway build indexed 237,735 papers from 292 source files into a
+  ~623 MB sqlite DB.
 - Free hobby tier (~$5/mo credit) is sufficient for the demo.
 - Egress is the main cost driver. Three mitigations baked in:
   1. `include_abstract` defaults to `false` on `/v1/search` — abstracts are only sent on `/v1/paper/{conf}/{id}`.

--- a/tools/query-api/README.md
+++ b/tools/query-api/README.md
@@ -47,13 +47,13 @@ PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py topic_evo
 ## Deployment
 
 ### Railway
-- Live demo used by the MCP server and Skill defaults:
+- Contributor-hosted live demo for evaluation:
   `https://api-production-18d3.up.railway.app`.
 - Use `tools/query-api` as the Railway upload/build root.
 - The Docker build fetches the paperlists JSON corpus from GitHub inside Railway and builds `papers.db` there. This avoids uploading hundreds of MB of tracked JSON through `railway up`.
 - Railway reads `tools/query-api/railway.json` and uses `Dockerfile` from this directory.
 - Runtime defaults to **4 Uvicorn workers** (`WEB_CONCURRENCY=4`). The rate-limit state is sqlite-backed (`paperlists_api/ratelimit.py`, separate writable file at `/tmp/paperlists-ratelimit.db`) so all workers share one bucket per IP. No risk of `N×limit` bypass from sticky worker routing.
-- `PAPERLISTS_TRUST_PROXY` defaults to `"auto"`, which auto-enables XFF-trust whenever a known platform marker is present in the env (Railway / HF Spaces / Fly / Render / Vercel / Cloud Run / Azure App Service). Set it to `"1"` or `"0"` to override. On any host **not** in that list, set `PAPERLISTS_TRUST_PROXY=1` explicitly or every visitor will share one rate-limit bucket because `req.client.host` resolves to the proxy address. Uvicorn is **not** started with `--forwarded-allow-ips=*` — that flag would let uvicorn itself rewrite `request.client.host` from XFF *before* the middleware runs, defeating the trust gate.
+- `PAPERLISTS_TRUST_PROXY` defaults to `"auto"`, which auto-enables proxy-header trust whenever a known platform marker is present in the env (Railway / HF Spaces / Fly / Render / Vercel / Cloud Run / Azure App Service). Set it to `"1"` or `"0"` to override. On any host **not** in that list, set `PAPERLISTS_TRUST_PROXY=1` explicitly or every visitor will share one rate-limit bucket because `req.client.host` resolves to the proxy address. The app prefers `X-Real-IP` (Railway) and falls back to the left-most `X-Forwarded-For`. Uvicorn is **not** started with `--forwarded-allow-ips=*` — that flag would let uvicorn itself rewrite `request.client.host` from XFF *before* the middleware runs, defeating the trust gate.
 - Current Railway build indexed 237,735 papers from 292 source files into a
   ~623 MB sqlite DB.
 - Free hobby tier (~$5/mo credit) is sufficient for the demo.
@@ -61,6 +61,10 @@ PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py topic_evo
   1. `include_abstract` defaults to `false` on `/v1/search` — abstracts are only sent on `/v1/paper/{conf}/{id}`.
   2. Token-bucket rate limiter (default 60 req/min/IP, burst 20). Tune via `PAPERLISTS_RATE_PER_MIN`, `PAPERLISTS_RATE_BURST`. Bucket size capped at 10k rows with 30 min stale eviction (`PAPERLISTS_RATE_BUCKET_MAX`, `PAPERLISTS_RATE_STALE_SEC`). GC sweeps run probabilistically (~1% of requests).
   3. Response field whitelist on cards — large fields like `bibtex`, `reviewers`, `or_profile` are never returned.
+- Broad analysis endpoints (`topic_evolution`, `compare_periods`, and
+  `field_landscape`) count matches before in-memory aggregation and return
+  `400 {"error":"too_many_matches"}` above 50k rows. `/v1/search` caps
+  `offset` at 10k to keep deep pagination from tying up workers.
 
 ### HF Spaces / Fly.io / self-hosted
 Same Dockerfile, just point at a different host. The index step is the slow part (~1–2 min on cold build).

--- a/tools/query-api/README.md
+++ b/tools/query-api/README.md
@@ -1,6 +1,6 @@
 # paperlists-api
 
-A small FastAPI service that exposes the [papercopilot/paperlists](https://github.com/papercopilot/paperlists) corpus over HTTPS, so AI agents (via the companion MCP server, or any HTTP client) can run **trend-focused** queries without downloading the ~830 MB of raw JSON.
+A small FastAPI service that exposes the [papercopilot/paperlists](https://github.com/papercopilot/paperlists) corpus over HTTPS or localhost, so AI agents (via the companion MCP server, the bundled Skill, or any HTTP client) can run **trend-focused** queries without loading hundreds of JSON files on every call.
 
 ## What it does
 
@@ -19,26 +19,44 @@ Built around the observation that flat keyword search is already well served by 
 | `GET /v1/paper/{conf}/{paper_id}` | Single record (full schema, including abstract) |
 | `GET /v1/coverage` | What conferences/years are indexed |
 
+Trend-style endpoints default to `exclude_rejected=true`, matching `/v1/search`
+so survey counts do not mix accepted/poster papers with rejected or withdrawn
+submissions. Set `exclude_rejected=false` for raw corpus diagnostics. Endpoints
+that summarize a field (`topic_trend`, `topic_evolution`, `compare_periods`,
+`field_landscape`, and `search`) also accept `conferences=iclr,nips,icml` style
+comma-separated filters where relevant.
+
 Implementation: sqlite FTS5 over a flattened `papers` table built from the repo's JSON files. Index lives in `papers.db`. Build it locally with:
 
 ```bash
 cd tools/query-api
-pip install -e .
-python -m paperlists_api.indexer ../.. ./papers.db
-PAPERLISTS_DB=$PWD/papers.db uvicorn paperlists_api.main:app --reload
+uv run python -m paperlists_api.indexer ../.. ./papers.db
+PAPERLISTS_DB=$PWD/papers.db uv run uvicorn paperlists_api.main:app --reload
 ```
 
 Then `open http://localhost:8000/docs` for the interactive API browser.
 
+For Skill verification, use the same API through the bundled client:
+
+```bash
+cd ../skill
+PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py coverage
+PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py topic_evolution q="agent" year_from=2020 year_to=2025 window=1
+```
+
 ## Deployment
 
 ### Railway
-- Connect this fork to Railway, set the **build context to the repo root** (so the Dockerfile can `COPY` the conference directories).
-- Railway reads `tools/query-api/railway.json` and uses `tools/query-api/Dockerfile`.
+- Use `tools/query-api` as the Railway upload/build root.
+- The Docker build fetches the paperlists JSON corpus from GitHub inside Railway and builds `papers.db` there. This avoids uploading hundreds of MB of tracked JSON through `railway up`.
+- Railway reads `tools/query-api/railway.json` and uses `Dockerfile` from this directory.
+- Runtime defaults to **4 Uvicorn workers** (`WEB_CONCURRENCY=4`). The rate-limit state is sqlite-backed (`paperlists_api/ratelimit.py`, separate writable file at `/tmp/paperlists-ratelimit.db`) so all workers share one bucket per IP. No risk of `N×limit` bypass from sticky worker routing.
+- `PAPERLISTS_TRUST_PROXY` defaults to `"auto"`, which auto-enables XFF-trust whenever a known platform marker is present in the env (Railway / HF Spaces / Fly / Render / Vercel / Cloud Run / Azure App Service). Set it to `"1"` or `"0"` to override. On any host **not** in that list, set `PAPERLISTS_TRUST_PROXY=1` explicitly or every visitor will share one rate-limit bucket because `req.client.host` resolves to the proxy address. Uvicorn is **not** started with `--forwarded-allow-ips=*` — that flag would let uvicorn itself rewrite `request.client.host` from XFF *before* the middleware runs, defeating the trust gate.
 - Free hobby tier (~$5/mo credit) is sufficient for the demo.
-- Egress is the main cost driver. Two mitigations baked in:
+- Egress is the main cost driver. Three mitigations baked in:
   1. `include_abstract` defaults to `false` on `/v1/search` — abstracts are only sent on `/v1/paper/{conf}/{id}`.
-  2. Token-bucket rate limiter (default 60 req/min/IP, configurable via `PAPERLISTS_RATE_PER_MIN`).
+  2. Token-bucket rate limiter (default 60 req/min/IP, burst 20). Tune via `PAPERLISTS_RATE_PER_MIN`, `PAPERLISTS_RATE_BURST`. Bucket size capped at 10k rows with 30 min stale eviction (`PAPERLISTS_RATE_BUCKET_MAX`, `PAPERLISTS_RATE_STALE_SEC`). GC sweeps run probabilistically (~1% of requests).
+  3. Response field whitelist on cards — large fields like `bibtex`, `reviewers`, `or_profile` are never returned.
 
 ### HF Spaces / Fly.io / self-hosted
 Same Dockerfile, just point at a different host. The index step is the slow part (~1–2 min on cold build).

--- a/tools/query-api/README.md
+++ b/tools/query-api/README.md
@@ -1,0 +1,50 @@
+# paperlists-api
+
+A small FastAPI service that exposes the [papercopilot/paperlists](https://github.com/papercopilot/paperlists) corpus over HTTPS, so AI agents (via the companion MCP server, or any HTTP client) can run **trend-focused** queries without downloading the ~830 MB of raw JSON.
+
+## What it does
+
+Built around the observation that flat keyword search is already well served by [papercopilot.com](https://papercopilot.com). The API's first-class verbs are about **how research areas evolve**:
+
+| Endpoint | Use case |
+|---|---|
+| `GET /v1/topic_trend` | Yearly paper count + citation-weighted volume for a topic |
+| `GET /v1/topic_evolution` | Per-year (or per-window) top co-occurring keywords + landmark papers |
+| `GET /v1/compare_periods` | Diff a topic across two year ranges — what emerged / faded / sustained |
+| `GET /v1/author_trajectory` | Papers by an author across years |
+| `GET /v1/field_landscape` | Single-year snapshot for a field: top papers, authors, affiliations, keywords |
+| `GET /v1/conference_stats/{conf}/{year}` | Acceptance breakdown + rating/citation summary stats |
+| `GET /v1/top_papers/{conf}/{year}` | Ranked by citation or rating |
+| `GET /v1/search` | Standard FTS5 search (title/abstract/keywords/authors) |
+| `GET /v1/paper/{conf}/{paper_id}` | Single record (full schema, including abstract) |
+| `GET /v1/coverage` | What conferences/years are indexed |
+
+Implementation: sqlite FTS5 over a flattened `papers` table built from the repo's JSON files. Index lives in `papers.db`. Build it locally with:
+
+```bash
+cd tools/query-api
+pip install -e .
+python -m paperlists_api.indexer ../.. ./papers.db
+PAPERLISTS_DB=$PWD/papers.db uvicorn paperlists_api.main:app --reload
+```
+
+Then `open http://localhost:8000/docs` for the interactive API browser.
+
+## Deployment
+
+### Railway
+- Connect this fork to Railway, set the **build context to the repo root** (so the Dockerfile can `COPY` the conference directories).
+- Railway reads `tools/query-api/railway.json` and uses `tools/query-api/Dockerfile`.
+- Free hobby tier (~$5/mo credit) is sufficient for the demo.
+- Egress is the main cost driver. Two mitigations baked in:
+  1. `include_abstract` defaults to `false` on `/v1/search` — abstracts are only sent on `/v1/paper/{conf}/{id}`.
+  2. Token-bucket rate limiter (default 60 req/min/IP, configurable via `PAPERLISTS_RATE_PER_MIN`).
+
+### HF Spaces / Fly.io / self-hosted
+Same Dockerfile, just point at a different host. The index step is the slow part (~1–2 min on cold build).
+
+## Future / out of scope for v1
+- Incremental re-indexing on JSON updates (current build is full rebuild)
+- Affiliation normalization across `aff_unique_norm` variants
+- Embedding-based semantic search (would require a vector DB; deferred)
+- Cloudflare Workers + D1 port for near-zero idle cost

--- a/tools/query-api/paperlists_api/__init__.py
+++ b/tools/query-api/paperlists_api/__init__.py
@@ -1,0 +1,3 @@
+"""Paperlists query API — hosted HTTPS service over the paperlists corpus."""
+
+__version__ = "0.1.0"

--- a/tools/query-api/paperlists_api/db.py
+++ b/tools/query-api/paperlists_api/db.py
@@ -7,6 +7,9 @@ from contextlib import contextmanager
 from pathlib import Path
 
 DB_PATH = Path(os.environ.get("PAPERLISTS_DB", "papers.db")).resolve()
+DB_CACHE_KIB = int(os.environ.get("PAPERLISTS_DB_CACHE_KIB", "65536"))
+DB_MMAP_BYTES = int(os.environ.get("PAPERLISTS_DB_MMAP_BYTES", str(256 * 1024 * 1024)))
+DB_IMMUTABLE = os.environ.get("PAPERLISTS_DB_IMMUTABLE", "0") == "1"
 
 
 def _row_factory(cursor, row):
@@ -15,8 +18,13 @@ def _row_factory(cursor, row):
 
 @contextmanager
 def connect():
-    conn = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+    immutable = "&immutable=1" if DB_IMMUTABLE else ""
+    conn = sqlite3.connect(f"file:{DB_PATH}?mode=ro{immutable}", uri=True, timeout=30)
     conn.row_factory = _row_factory
+    conn.execute("PRAGMA query_only=ON")
+    conn.execute("PRAGMA temp_store=MEMORY")
+    conn.execute(f"PRAGMA cache_size=-{DB_CACHE_KIB}")
+    conn.execute(f"PRAGMA mmap_size={DB_MMAP_BYTES}")
     try:
         yield conn
     finally:

--- a/tools/query-api/paperlists_api/db.py
+++ b/tools/query-api/paperlists_api/db.py
@@ -1,0 +1,23 @@
+"""Thin sqlite connection helpers."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+DB_PATH = Path(os.environ.get("PAPERLISTS_DB", "papers.db")).resolve()
+
+
+def _row_factory(cursor, row):
+    return {col[0]: row[i] for i, col in enumerate(cursor.description)}
+
+
+@contextmanager
+def connect():
+    conn = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+    conn.row_factory = _row_factory
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/tools/query-api/paperlists_api/indexer.py
+++ b/tools/query-api/paperlists_api/indexer.py
@@ -1,0 +1,249 @@
+"""Build a sqlite FTS5 index from the paperlists JSON corpus.
+
+Run directly:  python -m paperlists_api.indexer <repo_root> <out.db>
+
+The repo root is expected to contain conference subdirectories
+(iclr/, nips/, cvpr/, ...) holding `<conf><year>.json` files.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+FILENAME_RE = re.compile(r"^([a-z0-9]+?)(\d{4})\.json$")
+
+# Directories under repo root that hold paperlist JSON files.
+# Anything else (tools/, .git/, etc.) is ignored.
+KNOWN_CONF_DIRS = {
+    "3dv", "aaai", "acl", "acml", "aistats", "alt", "automl", "coling",
+    "colm", "colt", "corl", "cvpr", "eccv", "emnlp", "iccv", "iclr",
+    "icml", "icra", "ijcai", "iros", "kdd", "naacl", "nips", "rss",
+    "siggraph", "siggraphasia", "uai", "wacv", "www", "ai4x",
+}
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS papers (
+    id           INTEGER PRIMARY KEY,
+    conf         TEXT NOT NULL,
+    year         INTEGER NOT NULL,
+    paper_id     TEXT,
+    title        TEXT NOT NULL,
+    abstract     TEXT,
+    keywords     TEXT,
+    authors      TEXT,
+    affiliations TEXT,
+    primary_area TEXT,
+    status       TEXT,
+    track        TEXT,
+    site         TEXT,
+    openreview   TEXT,
+    pdf          TEXT,
+    rating_avg   REAL,
+    confidence_avg REAL,
+    gs_citation  INTEGER,
+    UNIQUE(conf, year, paper_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_papers_conf_year   ON papers(conf, year);
+CREATE INDEX IF NOT EXISTS idx_papers_status      ON papers(status);
+CREATE INDEX IF NOT EXISTS idx_papers_rating      ON papers(rating_avg);
+CREATE INDEX IF NOT EXISTS idx_papers_citation    ON papers(gs_citation);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS papers_fts USING fts5(
+    title, abstract, keywords, authors,
+    content='papers', content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+CREATE TABLE IF NOT EXISTS source_files (
+    path  TEXT PRIMARY KEY,
+    mtime REAL NOT NULL,
+    rows  INTEGER NOT NULL,
+    indexed_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+TRIGGERS = """
+CREATE TRIGGER IF NOT EXISTS papers_ai AFTER INSERT ON papers BEGIN
+    INSERT INTO papers_fts(rowid, title, abstract, keywords, authors)
+    VALUES (new.id, new.title, new.abstract, new.keywords, new.authors);
+END;
+CREATE TRIGGER IF NOT EXISTS papers_ad AFTER DELETE ON papers BEGIN
+    INSERT INTO papers_fts(papers_fts, rowid, title, abstract, keywords, authors)
+    VALUES ('delete', old.id, old.title, old.abstract, old.keywords, old.authors);
+END;
+CREATE TRIGGER IF NOT EXISTS papers_au AFTER UPDATE ON papers BEGIN
+    INSERT INTO papers_fts(papers_fts, rowid, title, abstract, keywords, authors)
+    VALUES ('delete', old.id, old.title, old.abstract, old.keywords, old.authors);
+    INSERT INTO papers_fts(rowid, title, abstract, keywords, authors)
+    VALUES (new.id, new.title, new.abstract, new.keywords, new.authors);
+END;
+"""
+
+
+def _coerce_float(v):
+    """Convert to float. Handles paperlists' [mean, std] list format."""
+    if v is None or v == "":
+        return None
+    if isinstance(v, list):
+        if not v:
+            return None
+        v = v[0]
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(v):
+    if v is None or v == "":
+        return None
+    if isinstance(v, list):
+        if not v:
+            return None
+        v = v[0]
+    try:
+        f = float(v)
+        # paperlists uses -1 as a sentinel for "not crawled yet" on citations.
+        # Store as NULL so it doesn't pollute aggregates.
+        if f < 0:
+            return None
+        return int(f)
+    except (TypeError, ValueError):
+        return None
+
+
+def _norm_str(v) -> str:
+    if v is None:
+        return ""
+    return str(v).strip()
+
+
+def discover_files(repo_root: Path) -> list[tuple[str, int, Path]]:
+    """Return list of (conf, year, path) for every conference JSON file."""
+    out: list[tuple[str, int, Path]] = []
+    for conf_dir in sorted(repo_root.iterdir()):
+        if not conf_dir.is_dir():
+            continue
+        if conf_dir.name not in KNOWN_CONF_DIRS:
+            continue
+        for fp in sorted(conf_dir.iterdir()):
+            m = FILENAME_RE.match(fp.name)
+            if not m:
+                continue
+            conf, year = m.group(1), int(m.group(2))
+            out.append((conf, year, fp))
+    return out
+
+
+def iter_records(fp: Path) -> Iterable[dict]:
+    with fp.open() as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        yield from data
+    elif isinstance(data, dict):
+        yield data
+
+
+def ingest_file(conn: sqlite3.Connection, conf: str, year: int, fp: Path) -> int:
+    cur = conn.cursor()
+    cur.execute("DELETE FROM papers WHERE conf=? AND year=?", (conf, year))
+    rows = []
+    for rec in iter_records(fp):
+        title = _norm_str(rec.get("title"))
+        if not title:
+            continue
+        rows.append((
+            conf,
+            year,
+            _norm_str(rec.get("id")),
+            title,
+            _norm_str(rec.get("abstract")),
+            _norm_str(rec.get("keywords")),
+            _norm_str(rec.get("author") or rec.get("author_site")),
+            _norm_str(rec.get("aff_unique_norm") or rec.get("aff")),
+            _norm_str(rec.get("primary_area")),
+            _norm_str(rec.get("status")),
+            _norm_str(rec.get("track")),
+            _norm_str(rec.get("site")),
+            _norm_str(rec.get("openreview")),
+            _norm_str(rec.get("pdf")),
+            _coerce_float(rec.get("rating_avg")),
+            _coerce_float(rec.get("confidence_avg")),
+            _coerce_int(rec.get("gs_citation")),
+        ))
+    cur.executemany(
+        """
+        INSERT OR IGNORE INTO papers
+        (conf, year, paper_id, title, abstract, keywords, authors,
+         affiliations, primary_area, status, track, site, openreview, pdf,
+         rating_avg, confidence_avg, gs_citation)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        rows,
+    )
+    return len(rows)
+
+
+def build_index(repo_root: Path, db_path: Path, *, force: bool = False) -> dict:
+    repo_root = repo_root.resolve()
+    db_path = db_path.resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.executescript("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")
+    conn.executescript(SCHEMA)
+    conn.executescript(TRIGGERS)
+
+    files = discover_files(repo_root)
+    existing = {row[0]: (row[1], row[2]) for row in conn.execute("SELECT path, mtime, rows FROM source_files")}
+
+    stats = {"files_total": len(files), "files_indexed": 0, "rows_indexed": 0, "skipped": 0}
+    t0 = time.time()
+    for conf, year, fp in files:
+        rel = str(fp.relative_to(repo_root))
+        mtime = fp.stat().st_mtime
+        if not force and rel in existing and abs(existing[rel][0] - mtime) < 1e-6:
+            stats["skipped"] += 1
+            continue
+        n = ingest_file(conn, conf, year, fp)
+        conn.execute(
+            "INSERT OR REPLACE INTO source_files(path, mtime, rows, indexed_at) VALUES (?,?,?,?)",
+            (rel, mtime, n, time.time()),
+        )
+        stats["files_indexed"] += 1
+        stats["rows_indexed"] += n
+        conn.commit()
+        print(f"  indexed {rel}: {n} rows", file=sys.stderr)
+
+    conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES ('built_at', ?)", (str(time.time()),))
+    conn.commit()
+    conn.execute("ANALYZE")
+    conn.close()
+    stats["elapsed_sec"] = round(time.time() - t0, 2)
+    return stats
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("usage: python -m paperlists_api.indexer <repo_root> <out.db> [--force]", file=sys.stderr)
+        return 2
+    force = "--force" in argv[3:]
+    stats = build_index(Path(argv[1]), Path(argv[2]), force=force)
+    print(json.dumps(stats, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/query-api/paperlists_api/indexer.py
+++ b/tools/query-api/paperlists_api/indexer.py
@@ -306,6 +306,8 @@ def build_index(repo_root: Path, db_path: Path, *, force: bool = False) -> dict:
     conn.commit()
     conn.execute("ANALYZE")
     conn.execute("PRAGMA optimize")
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     conn.close()
     stats["elapsed_sec"] = round(time.time() - t0, 2)
     return stats

--- a/tools/query-api/paperlists_api/indexer.py
+++ b/tools/query-api/paperlists_api/indexer.py
@@ -8,7 +8,7 @@ The repo root is expected to contain conference subdirectories
 from __future__ import annotations
 
 import json
-import os
+import hashlib
 import re
 import sqlite3
 import sys
@@ -16,16 +16,19 @@ import time
 from pathlib import Path
 from typing import Iterable
 
+try:
+    import orjson
+except ImportError:  # pragma: no cover - stdlib fallback for minimal installs
+    orjson = None
+
 FILENAME_RE = re.compile(r"^([a-z0-9]+?)(\d{4})\.json$")
 
-# Directories under repo root that hold paperlist JSON files.
-# Anything else (tools/, .git/, etc.) is ignored.
-KNOWN_CONF_DIRS = {
-    "3dv", "aaai", "acl", "acml", "aistats", "alt", "automl", "coling",
-    "colm", "colt", "corl", "cvpr", "eccv", "emnlp", "iccv", "iclr",
-    "icml", "icra", "ijcai", "iros", "kdd", "naacl", "nips", "rss",
-    "siggraph", "siggraphasia", "uai", "wacv", "www", "ai4x",
-}
+IGNORED_TOP_LEVEL_DIRS = {".git", ".github", "tools", "__pycache__"}
+# Ordered from most-stable to least-stable. `site` and `pdf` are URLs that some
+# source files reuse across distinct papers (e.g. siggraph2025.json repeats the
+# same `id` for 4-5 paper rows); we still try them, but ingest_file applies a
+# within-file dedup safety net so collisions don't silently drop papers.
+ID_FIELDS = ("id", "doi", "arxiv", "openreview", "url_paper", "site", "pdf")
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS papers (
@@ -33,6 +36,8 @@ CREATE TABLE IF NOT EXISTS papers (
     conf         TEXT NOT NULL,
     year         INTEGER NOT NULL,
     paper_id     TEXT,
+    source_path  TEXT,
+    source_index INTEGER,
     title        TEXT NOT NULL,
     abstract     TEXT,
     keywords     TEXT,
@@ -130,13 +135,48 @@ def _norm_str(v) -> str:
     return str(v).strip()
 
 
+def _load_json(fp: Path):
+    if orjson is not None:
+        return orjson.loads(fp.read_bytes())
+    with fp.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _paper_id(rec: dict, conf: str, year: int, source_index: int) -> str:
+    return _paper_id_candidates(rec, conf, year, source_index)[0]
+
+
+def _paper_id_candidates(rec: dict, conf: str, year: int, source_index: int) -> list[str]:
+    candidates: list[str] = []
+    for field in ID_FIELDS:
+        value = _norm_str(rec.get(field))
+        if value:
+            candidates.append(value)
+    title = _norm_str(rec.get("title"))
+    authors = _norm_str(rec.get("author") or rec.get("author_site"))
+    digest = hashlib.sha1(
+        f"{conf}|{year}|{source_index}|{title}|{authors}".encode("utf-8")
+    ).hexdigest()
+    candidates.append(f"generated:{digest[:16]}")
+    return candidates
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(papers)")}
+    if "source_path" not in columns:
+        conn.execute("ALTER TABLE papers ADD COLUMN source_path TEXT")
+    if "source_index" not in columns:
+        conn.execute("ALTER TABLE papers ADD COLUMN source_index INTEGER")
+
+
 def discover_files(repo_root: Path) -> list[tuple[str, int, Path]]:
     """Return list of (conf, year, path) for every conference JSON file."""
     out: list[tuple[str, int, Path]] = []
     for conf_dir in sorted(repo_root.iterdir()):
         if not conf_dir.is_dir():
             continue
-        if conf_dir.name not in KNOWN_CONF_DIRS:
+        if conf_dir.name.startswith(".") or conf_dir.name in IGNORED_TOP_LEVEL_DIRS:
             continue
         for fp in sorted(conf_dir.iterdir()):
             m = FILENAME_RE.match(fp.name)
@@ -147,27 +187,46 @@ def discover_files(repo_root: Path) -> list[tuple[str, int, Path]]:
     return out
 
 
-def iter_records(fp: Path) -> Iterable[dict]:
-    with fp.open() as f:
-        data = json.load(f)
+def iter_records(fp: Path) -> Iterable[tuple[int, dict]]:
+    data = _load_json(fp)
     if isinstance(data, list):
-        yield from data
+        for idx, rec in enumerate(data):
+            if isinstance(rec, dict):
+                yield idx, rec
     elif isinstance(data, dict):
-        yield data
+        yield 0, data
 
 
-def ingest_file(conn: sqlite3.Connection, conf: str, year: int, fp: Path) -> int:
+def ingest_file(conn: sqlite3.Connection, conf: str, year: int, fp: Path, source_path: str) -> int:
     cur = conn.cursor()
     cur.execute("DELETE FROM papers WHERE conf=? AND year=?", (conf, year))
     rows = []
-    for rec in iter_records(fp):
+    seen_ids: set[str] = set()
+    dedup_collisions = 0
+    for source_index, rec in iter_records(fp):
         title = _norm_str(rec.get("title"))
         if not title:
             continue
+        pid_candidates = _paper_id_candidates(rec, conf, year, source_index)
+        pid = next((candidate for candidate in pid_candidates if candidate not in seen_ids), pid_candidates[-1])
+        # Within-file dedup safety net: a few source files (e.g. siggraph2025.json)
+        # reuse the same `id` for 4-5 distinct paper rows. Without this, the
+        # UNIQUE(conf, year, paper_id) constraint + INSERT OR IGNORE would
+        # silently drop ~300 SIGGRAPH papers and similar across other venues.
+        if pid in seen_ids:
+            authors = _norm_str(rec.get("author") or rec.get("author_site"))
+            digest = hashlib.sha1(
+                f"{conf}|{year}|{source_index}|{title}|{authors}".encode("utf-8")
+            ).hexdigest()
+            pid = f"dedup:{digest[:16]}"
+            dedup_collisions += 1
+        seen_ids.add(pid)
         rows.append((
             conf,
             year,
-            _norm_str(rec.get("id")),
+            pid,
+            source_path,
+            source_index,
             title,
             _norm_str(rec.get("abstract")),
             _norm_str(rec.get("keywords")),
@@ -186,14 +245,30 @@ def ingest_file(conn: sqlite3.Connection, conf: str, year: int, fp: Path) -> int
     cur.executemany(
         """
         INSERT OR IGNORE INTO papers
-        (conf, year, paper_id, title, abstract, keywords, authors,
+        (conf, year, paper_id, source_path, source_index, title, abstract, keywords, authors,
          affiliations, primary_area, status, track, site, openreview, pdf,
          rating_avg, confidence_avg, gs_citation)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         rows,
     )
-    return len(rows)
+    inserted = conn.execute(
+        "SELECT COUNT(*) AS n FROM papers WHERE conf=? AND year=?", (conf, year)
+    ).fetchone()[0]
+    dropped = len(rows) - inserted
+    if dropped > 0:
+        # Should be impossible after the within-file dedup, but flag loudly if
+        # the constraint still fires (e.g. a future schema change).
+        print(
+            f"  WARN {source_path}: {dropped} rows hit UNIQUE constraint after dedup",
+            file=sys.stderr,
+        )
+    if dedup_collisions > 0:
+        print(
+            f"  note {source_path}: rekeyed {dedup_collisions} colliding paper_id(s)",
+            file=sys.stderr,
+        )
+    return inserted
 
 
 def build_index(repo_root: Path, db_path: Path, *, force: bool = False) -> dict:
@@ -203,7 +278,7 @@ def build_index(repo_root: Path, db_path: Path, *, force: bool = False) -> dict:
 
     conn = sqlite3.connect(db_path)
     conn.executescript("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")
-    conn.executescript(SCHEMA)
+    ensure_schema(conn)
     conn.executescript(TRIGGERS)
 
     files = discover_files(repo_root)
@@ -217,7 +292,7 @@ def build_index(repo_root: Path, db_path: Path, *, force: bool = False) -> dict:
         if not force and rel in existing and abs(existing[rel][0] - mtime) < 1e-6:
             stats["skipped"] += 1
             continue
-        n = ingest_file(conn, conf, year, fp)
+        n = ingest_file(conn, conf, year, fp, rel)
         conn.execute(
             "INSERT OR REPLACE INTO source_files(path, mtime, rows, indexed_at) VALUES (?,?,?,?)",
             (rel, mtime, n, time.time()),
@@ -230,6 +305,7 @@ def build_index(repo_root: Path, db_path: Path, *, force: bool = False) -> dict:
     conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES ('built_at', ?)", (str(time.time()),))
     conn.commit()
     conn.execute("ANALYZE")
+    conn.execute("PRAGMA optimize")
     conn.close()
     stats["elapsed_sec"] = round(time.time() - t0, 2)
     return stats

--- a/tools/query-api/paperlists_api/main.py
+++ b/tools/query-api/paperlists_api/main.py
@@ -1,0 +1,232 @@
+"""FastAPI service exposing the paperlists corpus over HTTPS.
+
+Designed for hosted deployment (Railway / HF Spaces / Fly.io) so that
+casual users — including AI agents via the MCP wrapper — can query the
+full corpus without downloading the ~830MB of raw JSON.
+
+Endpoints are intentionally compact and trend-focused, since plain
+keyword search is already well served by papercopilot.com.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from . import __version__, queries
+from .db import DB_PATH, connect
+
+API_TITLE = "Paperlists Query API"
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+
+app = FastAPI(
+    title=API_TITLE,
+    version=__version__,
+    description=(
+        "AI-native query layer over the papercopilot/paperlists corpus. "
+        "Trend-focused endpoints (topic_trend, topic_evolution, "
+        "compare_periods, author_trajectory, field_landscape) are first-class — "
+        "raw keyword search remains available as /v1/search."
+    ),
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+# ---------- Tiny in-memory rate limiter ----------
+# Hosted demo on Railway free tier — protect egress. Per-IP token bucket.
+_RATE_BUCKET: dict[str, tuple[float, float]] = {}
+_RATE_PER_MIN = float(os.environ.get("PAPERLISTS_RATE_PER_MIN", "60"))
+_RATE_BURST = float(os.environ.get("PAPERLISTS_RATE_BURST", "20"))
+
+
+def _client_ip(req: Request) -> str:
+    fwd = req.headers.get("x-forwarded-for")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return req.client.host if req.client else "unknown"
+
+
+@app.middleware("http")
+async def rate_limit(request: Request, call_next):
+    if request.url.path in ("/", "/healthz", "/v1/coverage"):
+        return await call_next(request)
+    ip = _client_ip(request)
+    now = time.time()
+    tokens, last = _RATE_BUCKET.get(ip, (_RATE_BURST, now))
+    tokens = min(_RATE_BURST, tokens + (now - last) * (_RATE_PER_MIN / 60.0))
+    if tokens < 1.0:
+        return JSONResponse(
+            {"error": "rate_limited", "retry_after_sec": int((1.0 - tokens) * 60.0 / _RATE_PER_MIN)},
+            status_code=429,
+        )
+    _RATE_BUCKET[ip] = (tokens - 1.0, now)
+    return await call_next(request)
+
+
+# ---------- Routes ----------
+
+
+@app.get("/")
+def root():
+    return {
+        "name": API_TITLE,
+        "version": __version__,
+        "docs": "/docs",
+        "endpoints": [
+            "/v1/coverage",
+            "/v1/search",
+            "/v1/paper/{conf}/{paper_id}",
+            "/v1/topic_trend",
+            "/v1/topic_evolution",
+            "/v1/author_trajectory",
+            "/v1/field_landscape",
+            "/v1/compare_periods",
+            "/v1/conference_stats/{conf}/{year}",
+            "/v1/top_papers/{conf}/{year}",
+        ],
+        "source": "https://github.com/papercopilot/paperlists",
+    }
+
+
+@app.get("/healthz")
+def healthz():
+    return {"ok": True, "db": str(DB_PATH), "db_exists": DB_PATH.exists()}
+
+
+@app.get("/v1/coverage")
+def coverage():
+    with connect() as conn:
+        return queries.coverage(conn)
+
+
+@app.get("/v1/search")
+def search(
+    q: str = Query(..., min_length=1, max_length=200, description="Query string. FTS5 syntax accepted."),
+    conferences: Optional[str] = Query(None, description="Comma-separated conf list, e.g. 'iclr,nips,icml'."),
+    year_from: Optional[int] = Query(None, ge=1990, le=2100),
+    year_to: Optional[int] = Query(None, ge=1990, le=2100),
+    exclude_rejected: bool = Query(True),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    offset: int = Query(0, ge=0),
+    order_by: str = Query("relevance", pattern="^(relevance|year_desc|citation_desc|rating_desc)$"),
+    include_abstract: bool = Query(False, description="Include abstract in each result. Off by default to control egress."),
+):
+    confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
+    with connect() as conn:
+        return queries.search_papers(
+            conn,
+            q=q, conferences=confs,
+            year_from=year_from, year_to=year_to,
+            exclude_rejected=exclude_rejected,
+            limit=limit, offset=offset, order_by=order_by,
+            include_abstract=include_abstract,
+        )
+
+
+@app.get("/v1/paper/{conf}/{paper_id}")
+def get_paper(conf: str, paper_id: str):
+    with connect() as conn:
+        paper = queries.get_paper(conn, conf, paper_id)
+    if not paper:
+        raise HTTPException(status_code=404, detail="paper not found")
+    return paper
+
+
+@app.get("/v1/topic_trend")
+def topic_trend(
+    q: str = Query(..., min_length=1, max_length=200),
+    conferences: Optional[str] = Query(None),
+    year_from: Optional[int] = Query(None),
+    year_to: Optional[int] = Query(None),
+    exclude_rejected: bool = Query(True),
+):
+    confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
+    with connect() as conn:
+        return queries.topic_trend(
+            conn, q=q, conferences=confs,
+            year_from=year_from, year_to=year_to,
+            exclude_rejected=exclude_rejected,
+        )
+
+
+@app.get("/v1/topic_evolution")
+def topic_evolution(
+    q: str = Query(..., min_length=1, max_length=200),
+    year_from: int = Query(..., ge=1990, le=2100),
+    year_to: int = Query(..., ge=1990, le=2100),
+    window: int = Query(1, ge=1, le=5),
+    top_k: int = Query(15, ge=1, le=50),
+    conferences: Optional[str] = Query(None),
+):
+    confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
+    with connect() as conn:
+        return queries.topic_evolution(
+            conn, q=q, year_from=year_from, year_to=year_to,
+            window=window, top_k=top_k, conferences=confs,
+        )
+
+
+@app.get("/v1/author_trajectory")
+def author_trajectory(
+    name: str = Query(..., min_length=2, max_length=120),
+    year_from: Optional[int] = Query(None),
+    year_to: Optional[int] = Query(None),
+):
+    with connect() as conn:
+        return queries.author_trajectory(
+            conn, name=name, year_from=year_from, year_to=year_to,
+        )
+
+
+@app.get("/v1/field_landscape")
+def field_landscape(
+    q: str = Query(..., min_length=1, max_length=200),
+    year: int = Query(..., ge=1990, le=2100),
+    top_k: int = Query(10, ge=1, le=50),
+):
+    with connect() as conn:
+        return queries.field_landscape(conn, q=q, year=year, top_k=top_k)
+
+
+@app.get("/v1/compare_periods")
+def compare_periods(
+    q: str = Query(..., min_length=1, max_length=200),
+    period_a_from: int = Query(..., ge=1990, le=2100),
+    period_a_to: int = Query(..., ge=1990, le=2100),
+    period_b_from: int = Query(..., ge=1990, le=2100),
+    period_b_to: int = Query(..., ge=1990, le=2100),
+    top_k: int = Query(15, ge=1, le=50),
+):
+    with connect() as conn:
+        return queries.compare_periods(
+            conn, q=q,
+            period_a=(period_a_from, period_a_to),
+            period_b=(period_b_from, period_b_to),
+            top_k=top_k,
+        )
+
+
+@app.get("/v1/conference_stats/{conf}/{year}")
+def conference_stats(conf: str, year: int):
+    with connect() as conn:
+        return queries.conference_stats(conn, conf=conf, year=year)
+
+
+@app.get("/v1/top_papers/{conf}/{year}")
+def top_papers(
+    conf: str, year: int,
+    by: str = Query("gs_citation", pattern="^(gs_citation|rating|rating_avg)$"),
+    top_k: int = Query(20, ge=1, le=100),
+):
+    with connect() as conn:
+        return queries.top_papers(conn, conf=conf, year=year, by=by, top_k=top_k)

--- a/tools/query-api/paperlists_api/main.py
+++ b/tools/query-api/paperlists_api/main.py
@@ -18,11 +18,12 @@ from fastapi.responses import JSONResponse
 
 from . import __version__, queries, ratelimit
 from .db import DB_PATH, connect
-from .queries import FTSQueryError
+from .queries import FTSQueryError, TooManyMatchesError
 
 API_TITLE = "Paperlists Query API"
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 200
+MAX_OFFSET = 10_000
 
 app = FastAPI(
     title=API_TITLE,
@@ -50,6 +51,20 @@ async def _fts_query_error_handler(request: Request, exc: FTSQueryError):
         status_code=400,
     )
 
+
+@app.exception_handler(TooManyMatchesError)
+async def _too_many_matches_error_handler(request: Request, exc: TooManyMatchesError):
+    return JSONResponse(
+        {
+            "error": "too_many_matches",
+            "detail": str(exc),
+            "matches": exc.matches,
+            "max_matches": exc.max_matches,
+            "endpoint": exc.endpoint,
+        },
+        status_code=400,
+    )
+
 # ---------- Cross-worker rate limiter ----------
 # Backed by a tiny sqlite file (see paperlists_api/ratelimit.py). All
 # uvicorn workers see the same bucket for the same IP, so the per-IP quota
@@ -60,7 +75,8 @@ async def _fts_query_error_handler(request: Request, exc: FTSQueryError):
 #   "1"/"true"/"yes"   → always trust X-Forwarded-For
 #   "0"/"false"/"no"   → never trust XFF
 #   "auto" (default)   → trust if we detect a known trusted-proxy host
-#                        (Railway, HF Spaces). Avoids the failure mode where
+#                        (Railway, HF Spaces, Fly, Render, Vercel, Cloud Run,
+#                        Azure). Avoids the failure mode where
 #                        all users collapse into one bucket because the
 #                        operator forgot to set PAPERLISTS_TRUST_PROXY=1 on
 #                        a Railway deploy.
@@ -98,9 +114,13 @@ def _client_ip(req: Request) -> str:
     without `--forwarded-allow-ips=*`, so its default (trust 127.0.0.1
     only) keeps `req.client.host` honest. When `_TRUST_PROXY` is set
     (explicitly via env or auto-detected from a platform marker), we read
-    XFF and take the left-most entry as the original client.
+    Railway documents `X-Real-IP` as the client IP header; many other hosts
+    use XFF. Prefer `X-Real-IP`, then take the left-most XFF entry.
     """
     if _TRUST_PROXY:
+        real_ip = req.headers.get("x-real-ip")
+        if real_ip:
+            return real_ip.strip() or "unknown"
         fwd = req.headers.get("x-forwarded-for")
         if fwd:
             return fwd.split(",")[0].strip() or "unknown"
@@ -174,7 +194,7 @@ def search(
     year_to: Optional[int] = Query(None, ge=1990, le=2100),
     exclude_rejected: bool = Query(True),
     limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
-    offset: int = Query(0, ge=0),
+    offset: int = Query(0, ge=0, le=MAX_OFFSET, description="Pagination offset. Capped to keep deep FTS pagination bounded."),
     order_by: str = Query("relevance", pattern="^(relevance|year_desc|citation_desc|rating_desc)$"),
     include_abstract: bool = Query(False, description="Include abstract in each result. Off by default to control egress."),
     raw: bool = Query(False, description=_RAW_DESC),

--- a/tools/query-api/paperlists_api/main.py
+++ b/tools/query-api/paperlists_api/main.py
@@ -10,15 +10,15 @@ keyword search is already well served by papercopilot.com.
 from __future__ import annotations
 
 import os
-import time
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from . import __version__, queries
+from . import __version__, queries, ratelimit
 from .db import DB_PATH, connect
+from .queries import FTSQueryError
 
 API_TITLE = "Paperlists Query API"
 DEFAULT_LIMIT = 50
@@ -42,17 +42,68 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# ---------- Tiny in-memory rate limiter ----------
-# Hosted demo on Railway free tier — protect egress. Per-IP token bucket.
-_RATE_BUCKET: dict[str, tuple[float, float]] = {}
-_RATE_PER_MIN = float(os.environ.get("PAPERLISTS_RATE_PER_MIN", "60"))
-_RATE_BURST = float(os.environ.get("PAPERLISTS_RATE_BURST", "20"))
+
+@app.exception_handler(FTSQueryError)
+async def _fts_query_error_handler(request: Request, exc: FTSQueryError):
+    return JSONResponse(
+        {"error": "invalid_query", "detail": str(exc)},
+        status_code=400,
+    )
+
+# ---------- Cross-worker rate limiter ----------
+# Backed by a tiny sqlite file (see paperlists_api/ratelimit.py). All
+# uvicorn workers see the same bucket for the same IP, so the per-IP quota
+# survives a 4-worker Railway deployment. Single-worker setups work too —
+# the sqlite file is just an in-process map at that point.
+#
+# Trust-proxy resolution:
+#   "1"/"true"/"yes"   → always trust X-Forwarded-For
+#   "0"/"false"/"no"   → never trust XFF
+#   "auto" (default)   → trust if we detect a known trusted-proxy host
+#                        (Railway, HF Spaces). Avoids the failure mode where
+#                        all users collapse into one bucket because the
+#                        operator forgot to set PAPERLISTS_TRUST_PROXY=1 on
+#                        a Railway deploy.
+_TRUST_PROXY_ENV = os.environ.get("PAPERLISTS_TRUST_PROXY", "auto").lower()
+# Heuristic: these env vars are auto-injected by the platform's edge proxy.
+# If any is present we are behind that platform's proxy and XFF is
+# trustworthy. Operators on platforms NOT in this list MUST set
+# PAPERLISTS_TRUST_PROXY=1 explicitly — otherwise every visitor will share
+# one rate-limit bucket because req.client.host is the proxy's address.
+_PLATFORM_PROXY_MARKERS = (
+    "RAILWAY_ENVIRONMENT", "RAILWAY_PROJECT_ID",    # Railway
+    "SPACE_ID",                                       # HuggingFace Spaces
+    "FLY_APP_NAME",                                   # Fly.io
+    "RENDER",                                         # Render
+    "VERCEL",                                         # Vercel
+    "K_SERVICE", "K_REVISION",                        # Google Cloud Run / Knative
+    "WEBSITE_SITE_NAME",                              # Azure App Service
+)
+_DETECTED_PROXY_NAME = next(
+    (name for name in _PLATFORM_PROXY_MARKERS if os.environ.get(name)), None
+)
+if _TRUST_PROXY_ENV in ("1", "true", "yes"):
+    _TRUST_PROXY = True
+elif _TRUST_PROXY_ENV in ("0", "false", "no"):
+    _TRUST_PROXY = False
+else:  # "auto" (default) or anything unrecognized
+    _TRUST_PROXY = bool(_DETECTED_PROXY_NAME)
 
 
 def _client_ip(req: Request) -> str:
-    fwd = req.headers.get("x-forwarded-for")
-    if fwd:
-        return fwd.split(",")[0].strip()
+    """Return the IP to bucket against.
+
+    Critical: this MUST NOT trust user-supplied X-Forwarded-For unless we
+    know we're behind a proxy that overwrites it. Uvicorn is started
+    without `--forwarded-allow-ips=*`, so its default (trust 127.0.0.1
+    only) keeps `req.client.host` honest. When `_TRUST_PROXY` is set
+    (explicitly via env or auto-detected from a platform marker), we read
+    XFF and take the left-most entry as the original client.
+    """
+    if _TRUST_PROXY:
+        fwd = req.headers.get("x-forwarded-for")
+        if fwd:
+            return fwd.split(",")[0].strip() or "unknown"
     return req.client.host if req.client else "unknown"
 
 
@@ -61,15 +112,13 @@ async def rate_limit(request: Request, call_next):
     if request.url.path in ("/", "/healthz", "/v1/coverage"):
         return await call_next(request)
     ip = _client_ip(request)
-    now = time.time()
-    tokens, last = _RATE_BUCKET.get(ip, (_RATE_BURST, now))
-    tokens = min(_RATE_BURST, tokens + (now - last) * (_RATE_PER_MIN / 60.0))
-    if tokens < 1.0:
+    allowed, retry = ratelimit.check_and_consume(ip)
+    if not allowed:
         return JSONResponse(
-            {"error": "rate_limited", "retry_after_sec": int((1.0 - tokens) * 60.0 / _RATE_PER_MIN)},
+            {"error": "rate_limited", "retry_after_sec": retry},
             status_code=429,
+            headers={"Retry-After": str(retry)},
         )
-    _RATE_BUCKET[ip] = (tokens - 1.0, now)
     return await call_next(request)
 
 
@@ -109,9 +158,17 @@ def coverage():
         return queries.coverage(conn)
 
 
+_RAW_DESC = (
+    "If true, pass the query string to FTS5 verbatim — enables operators "
+    "(`foo OR bar`, `\"exact phrase\"`, `title:diffusion`, `reason*`) at "
+    "the cost of HTTP 400 on syntax errors. Default false: input is "
+    "split into terms and AND'd, safe for any user input."
+)
+
+
 @app.get("/v1/search")
 def search(
-    q: str = Query(..., min_length=1, max_length=200, description="Query string. FTS5 syntax accepted."),
+    q: str = Query(..., min_length=1, max_length=200, description="Query string. By default input is treated as AND'd terms; set raw=true for full FTS5 syntax."),
     conferences: Optional[str] = Query(None, description="Comma-separated conf list, e.g. 'iclr,nips,icml'."),
     year_from: Optional[int] = Query(None, ge=1990, le=2100),
     year_to: Optional[int] = Query(None, ge=1990, le=2100),
@@ -120,6 +177,7 @@ def search(
     offset: int = Query(0, ge=0),
     order_by: str = Query("relevance", pattern="^(relevance|year_desc|citation_desc|rating_desc)$"),
     include_abstract: bool = Query(False, description="Include abstract in each result. Off by default to control egress."),
+    raw: bool = Query(False, description=_RAW_DESC),
 ):
     confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
     with connect() as conn:
@@ -130,10 +188,11 @@ def search(
             exclude_rejected=exclude_rejected,
             limit=limit, offset=offset, order_by=order_by,
             include_abstract=include_abstract,
+            raw=raw,
         )
 
 
-@app.get("/v1/paper/{conf}/{paper_id}")
+@app.get("/v1/paper/{conf}/{paper_id:path}")
 def get_paper(conf: str, paper_id: str):
     with connect() as conn:
         paper = queries.get_paper(conn, conf, paper_id)
@@ -149,13 +208,14 @@ def topic_trend(
     year_from: Optional[int] = Query(None),
     year_to: Optional[int] = Query(None),
     exclude_rejected: bool = Query(True),
+    raw: bool = Query(False, description=_RAW_DESC),
 ):
     confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
     with connect() as conn:
         return queries.topic_trend(
             conn, q=q, conferences=confs,
             year_from=year_from, year_to=year_to,
-            exclude_rejected=exclude_rejected,
+            exclude_rejected=exclude_rejected, raw=raw,
         )
 
 
@@ -167,12 +227,15 @@ def topic_evolution(
     window: int = Query(1, ge=1, le=5),
     top_k: int = Query(15, ge=1, le=50),
     conferences: Optional[str] = Query(None),
+    exclude_rejected: bool = Query(True),
+    raw: bool = Query(False, description=_RAW_DESC),
 ):
     confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
     with connect() as conn:
         return queries.topic_evolution(
             conn, q=q, year_from=year_from, year_to=year_to,
             window=window, top_k=top_k, conferences=confs,
+            exclude_rejected=exclude_rejected, raw=raw,
         )
 
 
@@ -193,9 +256,17 @@ def field_landscape(
     q: str = Query(..., min_length=1, max_length=200),
     year: int = Query(..., ge=1990, le=2100),
     top_k: int = Query(10, ge=1, le=50),
+    conferences: Optional[str] = Query(None),
+    exclude_rejected: bool = Query(True),
+    raw: bool = Query(False, description=_RAW_DESC),
 ):
+    confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
     with connect() as conn:
-        return queries.field_landscape(conn, q=q, year=year, top_k=top_k)
+        return queries.field_landscape(
+            conn, q=q, year=year, top_k=top_k,
+            conferences=confs, exclude_rejected=exclude_rejected,
+            raw=raw,
+        )
 
 
 @app.get("/v1/compare_periods")
@@ -206,13 +277,20 @@ def compare_periods(
     period_b_from: int = Query(..., ge=1990, le=2100),
     period_b_to: int = Query(..., ge=1990, le=2100),
     top_k: int = Query(15, ge=1, le=50),
+    conferences: Optional[str] = Query(None),
+    exclude_rejected: bool = Query(True),
+    raw: bool = Query(False, description=_RAW_DESC),
 ):
+    confs = [c.strip().lower() for c in conferences.split(",")] if conferences else None
     with connect() as conn:
         return queries.compare_periods(
             conn, q=q,
             period_a=(period_a_from, period_a_to),
             period_b=(period_b_from, period_b_to),
             top_k=top_k,
+            conferences=confs,
+            exclude_rejected=exclude_rejected,
+            raw=raw,
         )
 
 
@@ -227,6 +305,10 @@ def top_papers(
     conf: str, year: int,
     by: str = Query("gs_citation", pattern="^(gs_citation|rating|rating_avg)$"),
     top_k: int = Query(20, ge=1, le=100),
+    exclude_rejected: bool = Query(True, description="Exclude Reject/Withdraw/Desk Reject from the ranking. Set False to inspect raw rejects for OpenReview venues."),
 ):
     with connect() as conn:
-        return queries.top_papers(conn, conf=conf, year=year, by=by, top_k=top_k)
+        return queries.top_papers(
+            conn, conf=conf, year=year, by=by,
+            top_k=top_k, exclude_rejected=exclude_rejected,
+        )

--- a/tools/query-api/paperlists_api/queries.py
+++ b/tools/query-api/paperlists_api/queries.py
@@ -12,10 +12,24 @@ from typing import Iterable, Optional
 
 EXCLUDED_STATUSES_DEFAULT = ("Withdraw", "Reject", "Withdrawn", "Rejected", "Desk Reject")
 _EXCLUDED_STATUSES_LOWER = tuple(s.lower() for s in EXCLUDED_STATUSES_DEFAULT)
+MAX_ANALYSIS_MATCHES = 50_000
 
 
 class FTSQueryError(ValueError):
     """User query couldn't be parsed by FTS5. API layer maps this to HTTP 400."""
+
+
+class TooManyMatchesError(ValueError):
+    """Analysis query matched too many rows to aggregate safely in one worker."""
+
+    def __init__(self, *, endpoint: str, matches: int, max_matches: int):
+        self.endpoint = endpoint
+        self.matches = matches
+        self.max_matches = max_matches
+        super().__init__(
+            f"{endpoint} matched {matches} papers; narrow the years, venues, "
+            f"or query terms below {max_matches}"
+        )
 
 
 # FTS5 input is treated as a *quoted phrase per token*, then AND-joined.
@@ -66,7 +80,9 @@ def _prepare_query(q: str, raw: bool) -> str:
     caller and let FTS5 parse the input as-is; the syntax-error → 400
     mapping in `_run_fts` still keeps malformed input from 500'ing."""
     if raw:
-        return (q or "").strip()
+        raw_query = (q or "").strip()
+        _validate_raw_fts_columns(raw_query)
+        return raw_query
     return sanitize_fts(q)
 
 
@@ -74,12 +90,6 @@ def _prepare_query(q: str, raw: bool) -> str:
 # server-side problem (missing table, locked db, schema drift, ...) and
 # should bubble up as 5xx rather than be mislabelled `invalid_query`.
 #
-# "no such column" looks server-side at first glance, but FTS5 emits it
-# when the user types a `bad_col:value` filter inside a raw MATCH — that's
-# a user parse error. We only honor this marker in raw mode (where users
-# can write column filters at all); in sanitized mode the sanitizer can
-# never produce a column-filter token, so a "no such column" there really
-# does indicate schema drift and should propagate.
 # Empirically derived by feeding bad input to FTS5; tests below pin the set.
 _FTS_PARSE_ERROR_MARKERS = (
     "fts5: syntax error",          # AND/OR/NEAR misuse, unbalanced parens
@@ -87,10 +97,44 @@ _FTS_PARSE_ERROR_MARKERS = (
     "malformed match",
     "unterminated string",         # unbalanced double-quote
     "parse error",
-    "no such column",              # raw-mode `badcol:value` filter typo
     "unknown special query",       # `*foo` and other special-query syntax errors
     "fts5: unknown",               # variants of the above
 )
+_ALLOWED_RAW_FTS_COLUMNS = {"title", "abstract", "keywords", "authors"}
+_RAW_COLUMN_FILTER_RE = re.compile(r"(?:^|[\s(])([A-Za-z_][A-Za-z0-9_]*)\s*:")
+_SQLITE_NO_SUCH_COLUMN_RE = re.compile(r"no such column:\s*([A-Za-z_][\w.]*)")
+
+
+def _raw_fts_user_column_error(msg: str, raw_query: str) -> bool:
+    """Return true when sqlite's `no such column` came from FTS5 syntax.
+
+    FTS5 reports both `badcol:value` and `foo -bar` as `no such column`,
+    which looks identical to a real SQL/schema bug. Treat it as user input
+    only when the identifier appears in the raw MATCH expression in one of
+    those FTS-specific forms. Dotted names (`p.status`) are SQL columns and
+    should propagate as server errors.
+    """
+    m = _SQLITE_NO_SUCH_COLUMN_RE.search(msg)
+    if not m:
+        return False
+    col = m.group(1).lower()
+    if "." in col:
+        return False
+    q = raw_query.lower()
+    return bool(
+        re.search(rf"(?:^|[\s(]){re.escape(col)}\s*:", q)
+        or re.search(rf"(?:^|[\s(])-{re.escape(col)}\b", q)
+    )
+
+
+def _validate_raw_fts_columns(q: str) -> None:
+    for m in _RAW_COLUMN_FILTER_RE.finditer(q or ""):
+        col = m.group(1).lower()
+        if col not in _ALLOWED_RAW_FTS_COLUMNS:
+            raise FTSQueryError(
+                f"unknown FTS5 column {col!r}; allowed columns are "
+                f"{', '.join(sorted(_ALLOWED_RAW_FTS_COLUMNS))}"
+            )
 
 
 def _run_fts(
@@ -118,10 +162,43 @@ def _run_fts(
         if not raw:
             raise
         msg = str(e).lower()
+        raw_query = str(params[0] if params else "")
+        if _raw_fts_user_column_error(msg, raw_query):
+            raise FTSQueryError(str(e)) from e
         if any(marker in msg for marker in _FTS_PARSE_ERROR_MARKERS):
             raise FTSQueryError(str(e)) from e
         # Looked like an operational/server error even in raw mode — leak it.
         raise
+
+
+def _enforce_analysis_match_cap(
+    conn: sqlite3.Connection,
+    count_sql: str,
+    params: list,
+    *,
+    raw: bool,
+    endpoint: str,
+    max_matches: Optional[int] = None,
+) -> int:
+    """Count FTS matches before broad in-memory aggregations.
+
+    Trend endpoints intentionally compute keyword / author / affiliation
+    counters in Python because their output shape is nested and agent-facing.
+    A broad query like "learning" over 15+ years can match a large fraction of
+    the corpus, so count first and fail closed instead of materializing every
+    row in a Railway worker.
+    """
+    if max_matches is None:
+        max_matches = MAX_ANALYSIS_MATCHES
+    rows = _run_fts(conn, count_sql, params, raw=raw)
+    matches = int(rows[0]["n"]) if rows else 0
+    if matches > max_matches:
+        raise TooManyMatchesError(
+            endpoint=endpoint,
+            matches=matches,
+            max_matches=max_matches,
+        )
+    return matches
 
 
 def _conf_filter(confs: Optional[list[str]]) -> tuple[str, list]:
@@ -311,8 +388,7 @@ def topic_trend(
         SELECT p.year AS year,
                p.conf AS conf,
                COUNT(*) AS papers,
-               COALESCE(SUM(p.gs_citation), 0) AS citations,
-               AVG(p.rating_avg) AS avg_rating
+               COALESCE(SUM(p.gs_citation), 0) AS citations
         FROM papers_fts
         JOIN papers p ON p.id = papers_fts.rowid
         WHERE papers_fts MATCH ?
@@ -381,17 +457,32 @@ def topic_evolution(
 
     conf_sql, conf_params = _conf_filter(conferences)
     excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
-    sql = f"""
-        SELECT p.keywords AS keywords, p.conf AS conf, p.title AS title,
-               p.gs_citation AS cites, p.rating_avg AS rating, p.status AS status,
-               p.year AS year, p.paper_id AS paper_id
+    from_where_sql = f"""
         FROM papers_fts
         JOIN papers p ON p.id = papers_fts.rowid
         WHERE papers_fts MATCH ?
           AND p.year BETWEEN ? AND ?
           {conf_sql}{excl_sql}
     """
-    rows = _run_fts(conn, sql, [q_clean, year_from, year_to, *conf_params, *excl_params], raw=raw)
+    params = [q_clean, year_from, year_to, *conf_params, *excl_params]
+    total_matches = _enforce_analysis_match_cap(
+        conn,
+        f"SELECT COUNT(*) AS n {from_where_sql}",
+        params,
+        raw=raw,
+        endpoint="topic_evolution",
+    )
+    rows = _run_fts(
+        conn,
+        f"""
+        SELECT p.keywords AS keywords, p.conf AS conf, p.title AS title,
+               p.gs_citation AS cites, p.rating_avg AS rating, p.status AS status,
+               p.year AS year, p.paper_id AS paper_id
+        {from_where_sql}
+        """,
+        params,
+        raw=raw,
+    )
 
     buckets: dict[int, dict] = {}
     y = year_from
@@ -479,7 +570,7 @@ def topic_evolution(
             ],
         })
 
-    return {"query": q, "window": window, "windows": windows}
+    return {"query": q, "window": window, "total_matches": total_matches, "windows": windows}
 
 
 def author_trajectory(
@@ -547,17 +638,28 @@ def field_landscape(
 
     conf_sql, conf_params = _conf_filter(conferences)
     excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
+    from_where_sql = f"""
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ? AND p.year = ?
+          {conf_sql}{excl_sql}
+    """
+    params = [q_clean, year, *conf_params, *excl_params]
+    _enforce_analysis_match_cap(
+        conn,
+        f"SELECT COUNT(*) AS n {from_where_sql}",
+        params,
+        raw=raw,
+        endpoint="field_landscape",
+    )
     rows = _run_fts(
         conn,
         f"""
         SELECT p.conf, p.year, p.paper_id, p.title, p.authors, p.affiliations,
                p.keywords, p.gs_citation, p.rating_avg, p.status, p.openreview, p.site
-        FROM papers_fts
-        JOIN papers p ON p.id = papers_fts.rowid
-        WHERE papers_fts MATCH ? AND p.year = ?
-          {conf_sql}{excl_sql}
+        {from_where_sql}
         """,
-        [q_clean, year, *conf_params, *excl_params],
+        params,
         raw=raw,
     )
 
@@ -641,16 +743,27 @@ def compare_periods(
     hi = max(period_a[1], period_b[1])
     conf_sql, conf_params = _conf_filter(conferences)
     excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
-    rows = _run_fts(
-        conn,
-        f"""
-        SELECT p.authors, p.affiliations, p.keywords, p.year
+    from_where_sql = f"""
         FROM papers_fts
         JOIN papers p ON p.id = papers_fts.rowid
         WHERE papers_fts MATCH ? AND p.year BETWEEN ? AND ?
           {conf_sql}{excl_sql}
+    """
+    params = [q_clean, lo, hi, *conf_params, *excl_params]
+    total_matches = _enforce_analysis_match_cap(
+        conn,
+        f"SELECT COUNT(*) AS n {from_where_sql}",
+        params,
+        raw=raw,
+        endpoint="compare_periods",
+    )
+    rows = _run_fts(
+        conn,
+        f"""
+        SELECT p.authors, p.affiliations, p.keywords, p.year
+        {from_where_sql}
         """,
-        [q_clean, lo, hi, *conf_params, *excl_params],
+        params,
         raw=raw,
     )
 
@@ -694,6 +807,7 @@ def compare_periods(
 
     return {
         "query": q,
+        "total_matches": total_matches,
         "period_a": _period_meta(period_a, a["n_papers"]),
         "period_b": _period_meta(period_b, b["n_papers"]),
         "keyword_diff": _diff(a["keywords"], b["keywords"], top_k),

--- a/tools/query-api/paperlists_api/queries.py
+++ b/tools/query-api/paperlists_api/queries.py
@@ -1,0 +1,538 @@
+"""Query primitives over the sqlite index.
+
+Kept separate from the FastAPI layer so the same functions can be reused
+from CLI tests, notebooks, or an offline `--mode local` MCP fallback.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections import Counter
+from typing import Iterable, Optional
+
+EXCLUDED_STATUSES_DEFAULT = ("Withdraw", "Reject", "Withdrawn", "Rejected", "Desk Reject")
+
+# FTS5 sanitizer.
+# - Strip characters that aren't word/space/quote.
+# - Treat hyphens as spaces (FTS5 reads `-token` as "NOT token", which breaks
+#   queries like "in-context learning"). Quoted hyphens are also fragile, so
+#   the safest behavior is plain whitespace AND.
+_FTS_BAD = re.compile(r"[^\w\s\"]+", flags=re.UNICODE)
+
+
+def sanitize_fts(q: str) -> str:
+    q = (q or "").replace("-", " ")
+    q = _FTS_BAD.sub(" ", q)
+    return " ".join(q.split())
+
+
+def _conf_filter(confs: Optional[list[str]]) -> tuple[str, list]:
+    if not confs:
+        return "", []
+    placeholders = ",".join("?" * len(confs))
+    return f" AND p.conf IN ({placeholders})", [c.lower() for c in confs]
+
+
+def _year_filter(year_from: Optional[int], year_to: Optional[int]) -> tuple[str, list]:
+    parts, params = [], []
+    if year_from is not None:
+        parts.append("p.year >= ?")
+        params.append(year_from)
+    if year_to is not None:
+        parts.append("p.year <= ?")
+        params.append(year_to)
+    if not parts:
+        return "", []
+    return " AND " + " AND ".join(parts), params
+
+
+def _exclude_rejected_filter(exclude: bool) -> tuple[str, list]:
+    if not exclude:
+        return "", []
+    placeholders = ",".join("?" * len(EXCLUDED_STATUSES_DEFAULT))
+    return f" AND (p.status IS NULL OR p.status NOT IN ({placeholders}))", list(EXCLUDED_STATUSES_DEFAULT)
+
+
+def _row_to_card(row: dict, *, include_abstract: bool) -> dict:
+    out = {
+        "conf": row["conf"],
+        "year": row["year"],
+        "paper_id": row["paper_id"],
+        "title": row["title"],
+        "authors": row["authors"],
+        "status": row["status"],
+        "track": row["track"],
+        "site": row["site"],
+        "openreview": row["openreview"],
+        "pdf": row["pdf"],
+        "rating_avg": row["rating_avg"],
+        "gs_citation": row["gs_citation"],
+        "keywords": row["keywords"],
+        "primary_area": row["primary_area"],
+    }
+    if include_abstract:
+        out["abstract"] = row["abstract"]
+    return out
+
+
+def search_papers(
+    conn: sqlite3.Connection,
+    *,
+    q: str,
+    conferences: Optional[list[str]] = None,
+    year_from: Optional[int] = None,
+    year_to: Optional[int] = None,
+    exclude_rejected: bool = True,
+    limit: int = 50,
+    offset: int = 0,
+    order_by: str = "relevance",
+    include_abstract: bool = False,
+) -> dict:
+    """Full-text search across title/abstract/keywords/authors."""
+    q_clean = sanitize_fts(q)
+    if not q_clean:
+        return {"total": 0, "results": []}
+
+    conf_sql, conf_params = _conf_filter(conferences)
+    year_sql, year_params = _year_filter(year_from, year_to)
+    excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
+
+    order_sql = {
+        "relevance": "bm25(papers_fts)",
+        "year_desc": "p.year DESC, bm25(papers_fts)",
+        "citation_desc": "p.gs_citation DESC NULLS LAST, bm25(papers_fts)",
+        "rating_desc": "p.rating_avg DESC NULLS LAST, bm25(papers_fts)",
+    }.get(order_by, "bm25(papers_fts)")
+
+    sql = f"""
+        SELECT p.*
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ?
+          {conf_sql}{year_sql}{excl_sql}
+        ORDER BY {order_sql}
+        LIMIT ? OFFSET ?
+    """
+    params = [q_clean, *conf_params, *year_params, *excl_params, limit, offset]
+    rows = conn.execute(sql, params).fetchall()
+
+    count_sql = f"""
+        SELECT COUNT(*) AS n
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ?
+          {conf_sql}{year_sql}{excl_sql}
+    """
+    total = conn.execute(count_sql, [q_clean, *conf_params, *year_params, *excl_params]).fetchone()["n"]
+
+    return {
+        "total": total,
+        "results": [_row_to_card(r, include_abstract=include_abstract) for r in rows],
+    }
+
+
+def get_paper(conn: sqlite3.Connection, conf: str, paper_id: str) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT * FROM papers WHERE conf=? AND paper_id=? LIMIT 1",
+        (conf.lower(), paper_id),
+    ).fetchone()
+    if not row:
+        return None
+    out = _row_to_card(row, include_abstract=True)
+    out["affiliations"] = row["affiliations"]
+    out["confidence_avg"] = row["confidence_avg"]
+    return out
+
+
+def coverage(conn: sqlite3.Connection) -> dict:
+    rows = conn.execute(
+        "SELECT conf, year, COUNT(*) AS n FROM papers GROUP BY conf, year ORDER BY conf, year"
+    ).fetchall()
+    by_conf: dict[str, dict] = {}
+    total = 0
+    for r in rows:
+        d = by_conf.setdefault(r["conf"], {"years": {}, "total": 0})
+        d["years"][r["year"]] = r["n"]
+        d["total"] += r["n"]
+        total += r["n"]
+    built_at = conn.execute("SELECT value FROM meta WHERE key='built_at'").fetchone()
+    return {
+        "total_papers": total,
+        "conferences": by_conf,
+        "built_at": float(built_at["value"]) if built_at else None,
+    }
+
+
+# ---------- Research-evolution endpoints ----------
+
+def topic_trend(
+    conn: sqlite3.Connection,
+    *,
+    q: str,
+    conferences: Optional[list[str]] = None,
+    year_from: Optional[int] = None,
+    year_to: Optional[int] = None,
+    exclude_rejected: bool = True,
+) -> dict:
+    """Yearly paper count + citation-weighted volume for a topic query."""
+    q_clean = sanitize_fts(q)
+    if not q_clean:
+        return {"query": q, "series": []}
+
+    conf_sql, conf_params = _conf_filter(conferences)
+    year_sql, year_params = _year_filter(year_from, year_to)
+    excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
+
+    sql = f"""
+        SELECT p.year AS year,
+               p.conf AS conf,
+               COUNT(*) AS papers,
+               COALESCE(SUM(p.gs_citation), 0) AS citations,
+               AVG(p.rating_avg) AS avg_rating
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ?
+          {conf_sql}{year_sql}{excl_sql}
+        GROUP BY p.year, p.conf
+        ORDER BY p.year, p.conf
+    """
+    params = [q_clean, *conf_params, *year_params, *excl_params]
+    rows = conn.execute(sql, params).fetchall()
+
+    # Also yearly totals (any conference matching) for denominator/visualization.
+    yearly: dict[int, dict] = {}
+    for r in rows:
+        bucket = yearly.setdefault(r["year"], {"year": r["year"], "papers": 0, "citations": 0, "by_conf": {}})
+        bucket["papers"] += r["papers"]
+        bucket["citations"] += r["citations"]
+        bucket["by_conf"][r["conf"]] = {"papers": r["papers"], "citations": r["citations"]}
+    return {
+        "query": q,
+        "series": [yearly[y] for y in sorted(yearly)],
+    }
+
+
+# Stop-words to drop when extracting keyword/term drift.
+_STOPWORDS = set("""
+a an and are as at be by for from has have in is it its of on or such that the their then there these to was were will with we our you your this they them than but not no any all can may use using used new novel model models method methods learning deep neural network networks based approach paper task tasks
+""".split())
+
+
+def _tokenize_keywords(s: str) -> Iterable[str]:
+    if not s:
+        return []
+    # paperlists separates keywords with semicolons; fall back to splitting on commas/newlines.
+    parts = re.split(r"[;,\n]", s)
+    out = []
+    for p in parts:
+        kw = p.strip().lower()
+        if kw and kw not in _STOPWORDS and len(kw) > 1:
+            out.append(kw)
+    return out
+
+
+def topic_evolution(
+    conn: sqlite3.Connection,
+    *,
+    q: str,
+    year_from: int,
+    year_to: int,
+    window: int = 1,
+    top_k: int = 15,
+    conferences: Optional[list[str]] = None,
+) -> dict:
+    """Per-year (or per-window) top co-occurring keywords and top venues.
+
+    For each year window, fetch papers matching `q` and aggregate keyword
+    frequencies. Surfaces topic drift inside a research area.
+    """
+    q_clean = sanitize_fts(q)
+    if not q_clean or year_from > year_to:
+        return {"query": q, "windows": []}
+
+    conf_sql, conf_params = _conf_filter(conferences)
+
+    windows = []
+    y = year_from
+    while y <= year_to:
+        w_end = min(y + window - 1, year_to)
+        sql = f"""
+            SELECT p.keywords AS keywords, p.conf AS conf, p.title AS title,
+                   p.gs_citation AS cites, p.year AS year, p.paper_id AS paper_id
+            FROM papers_fts
+            JOIN papers p ON p.id = papers_fts.rowid
+            WHERE papers_fts MATCH ?
+              AND p.year BETWEEN ? AND ?
+              {conf_sql}
+        """
+        rows = conn.execute(sql, [q_clean, y, w_end, *conf_params]).fetchall()
+
+        kw_counter: Counter[str] = Counter()
+        conf_counter: Counter[str] = Counter()
+        for r in rows:
+            for kw in _tokenize_keywords(r["keywords"]):
+                kw_counter[kw] += 1
+            if r["conf"]:
+                conf_counter[r["conf"]] += 1
+
+        # Surface top-cited paper of the window as a "landmark".
+        landmarks = sorted(
+            [r for r in rows if r["cites"]],
+            key=lambda r: r["cites"] or 0,
+            reverse=True,
+        )[:5]
+
+        windows.append({
+            "year_from": y,
+            "year_to": w_end,
+            "n_papers": len(rows),
+            "top_keywords": kw_counter.most_common(top_k),
+            "top_venues": conf_counter.most_common(10),
+            "landmark_papers": [
+                {"conf": r["conf"], "year": r["year"], "paper_id": r["paper_id"],
+                 "title": r["title"], "gs_citation": r["cites"]}
+                for r in landmarks
+            ],
+        })
+        y = w_end + 1
+
+    return {"query": q, "window": window, "windows": windows}
+
+
+def author_trajectory(
+    conn: sqlite3.Connection,
+    *,
+    name: str,
+    year_from: Optional[int] = None,
+    year_to: Optional[int] = None,
+) -> dict:
+    """List papers by an author across years, grouped for trajectory analysis."""
+    if not name or not name.strip():
+        return {"name": name, "by_year": []}
+
+    # We match against the `authors` FTS column as an exact-phrase token.
+    q_phrase = f'authors:"{sanitize_fts(name)}"'
+    year_sql, year_params = _year_filter(year_from, year_to)
+    sql = f"""
+        SELECT p.year, p.conf, p.paper_id, p.title, p.authors, p.gs_citation, p.status
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ?
+          {year_sql}
+        ORDER BY p.year DESC, p.gs_citation DESC NULLS LAST
+    """
+    rows = conn.execute(sql, [q_phrase, *year_params]).fetchall()
+
+    by_year: dict[int, list] = {}
+    for r in rows:
+        # Confirm name actually appears (case-insensitive) — FTS porter stemming can over-match.
+        if name.lower() not in (r["authors"] or "").lower():
+            continue
+        by_year.setdefault(r["year"], []).append({
+            "conf": r["conf"], "paper_id": r["paper_id"], "title": r["title"],
+            "authors": r["authors"], "gs_citation": r["gs_citation"], "status": r["status"],
+        })
+
+    return {
+        "name": name,
+        "total_papers": sum(len(v) for v in by_year.values()),
+        "by_year": [
+            {"year": y, "papers": by_year[y]} for y in sorted(by_year, reverse=True)
+        ],
+    }
+
+
+def field_landscape(
+    conn: sqlite3.Connection,
+    *,
+    q: str,
+    year: int,
+    top_k: int = 10,
+) -> dict:
+    """Single-year snapshot for a field: top papers, top authors, top affiliations,
+    top keywords. Useful for 'state of <field> in <year>' summaries."""
+    q_clean = sanitize_fts(q)
+    if not q_clean:
+        return {"query": q, "year": year}
+
+    rows = conn.execute(
+        """
+        SELECT p.conf, p.year, p.paper_id, p.title, p.authors, p.affiliations,
+               p.keywords, p.gs_citation, p.rating_avg, p.status, p.openreview, p.site
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ? AND p.year = ?
+        """,
+        [q_clean, year],
+    ).fetchall()
+
+    author_counter: Counter[str] = Counter()
+    aff_counter: Counter[str] = Counter()
+    kw_counter: Counter[str] = Counter()
+    venue_counter: Counter[str] = Counter()
+    for r in rows:
+        for a in (r["authors"] or "").split(";"):
+            a = a.strip()
+            if a:
+                author_counter[a] += 1
+        for af in (r["affiliations"] or "").split(";"):
+            af = af.strip()
+            if af:
+                aff_counter[af] += 1
+        for kw in _tokenize_keywords(r["keywords"]):
+            kw_counter[kw] += 1
+        if r["conf"]:
+            venue_counter[r["conf"]] += 1
+
+    top_papers = sorted(
+        rows, key=lambda r: (r["gs_citation"] or 0, r["rating_avg"] or 0), reverse=True
+    )[:top_k]
+
+    return {
+        "query": q,
+        "year": year,
+        "n_papers": len(rows),
+        "top_papers": [
+            {"conf": r["conf"], "paper_id": r["paper_id"], "title": r["title"],
+             "authors": r["authors"], "gs_citation": r["gs_citation"],
+             "rating_avg": r["rating_avg"], "openreview": r["openreview"], "site": r["site"]}
+            for r in top_papers
+        ],
+        "top_authors": author_counter.most_common(top_k),
+        "top_affiliations": aff_counter.most_common(top_k),
+        "top_keywords": kw_counter.most_common(top_k),
+        "venue_distribution": venue_counter.most_common(),
+    }
+
+
+def compare_periods(
+    conn: sqlite3.Connection,
+    *,
+    q: str,
+    period_a: tuple[int, int],
+    period_b: tuple[int, int],
+    top_k: int = 15,
+) -> dict:
+    """Diff a topic between two year ranges. Returns keywords/authors/affiliations
+    that emerged, disappeared, or stayed across the two periods."""
+    def _bucket(years: tuple[int, int]) -> dict:
+        q_clean = sanitize_fts(q)
+        rows = conn.execute(
+            """
+            SELECT p.authors, p.affiliations, p.keywords, p.title, p.paper_id, p.conf, p.year, p.gs_citation
+            FROM papers_fts
+            JOIN papers p ON p.id = papers_fts.rowid
+            WHERE papers_fts MATCH ? AND p.year BETWEEN ? AND ?
+            """,
+            [q_clean, years[0], years[1]],
+        ).fetchall()
+        authors: Counter[str] = Counter()
+        affs: Counter[str] = Counter()
+        kws: Counter[str] = Counter()
+        for r in rows:
+            for a in (r["authors"] or "").split(";"):
+                a = a.strip()
+                if a:
+                    authors[a] += 1
+            for af in (r["affiliations"] or "").split(";"):
+                af = af.strip()
+                if af:
+                    affs[af] += 1
+            for kw in _tokenize_keywords(r["keywords"]):
+                kws[kw] += 1
+        return {"n_papers": len(rows), "authors": authors, "affiliations": affs, "keywords": kws}
+
+    a = _bucket(period_a)
+    b = _bucket(period_b)
+
+    def _diff(ca: Counter, cb: Counter, k: int):
+        emerged = [(x, cb[x]) for x in cb if x not in ca]
+        emerged.sort(key=lambda t: t[1], reverse=True)
+        faded = [(x, ca[x]) for x in ca if x not in cb]
+        faded.sort(key=lambda t: t[1], reverse=True)
+        sustained = [(x, ca[x], cb[x]) for x in ca if x in cb]
+        sustained.sort(key=lambda t: t[1] + t[2], reverse=True)
+        return {
+            "emerged": emerged[:k],
+            "faded": faded[:k],
+            "sustained": sustained[:k],
+        }
+
+    return {
+        "query": q,
+        "period_a": {"years": period_a, "n_papers": a["n_papers"]},
+        "period_b": {"years": period_b, "n_papers": b["n_papers"]},
+        "keyword_diff": _diff(a["keywords"], b["keywords"], top_k),
+        "author_diff": _diff(a["authors"], b["authors"], top_k),
+        "affiliation_diff": _diff(a["affiliations"], b["affiliations"], top_k),
+    }
+
+
+def conference_stats(conn: sqlite3.Connection, *, conf: str, year: int) -> dict:
+    rows = conn.execute(
+        "SELECT status, track, rating_avg, gs_citation FROM papers WHERE conf=? AND year=?",
+        (conf.lower(), year),
+    ).fetchall()
+    status_counter: Counter[str] = Counter()
+    track_counter: Counter[str] = Counter()
+    ratings = []
+    cites = []
+    for r in rows:
+        status_counter[r["status"] or "(unknown)"] += 1
+        track_counter[r["track"] or "(unknown)"] += 1
+        if r["rating_avg"] is not None:
+            ratings.append(r["rating_avg"])
+        if r["gs_citation"] is not None:
+            cites.append(r["gs_citation"])
+
+    def _summary(xs: list[float]) -> dict:
+        if not xs:
+            return {"n": 0}
+        xs_sorted = sorted(xs)
+        n = len(xs_sorted)
+        return {
+            "n": n,
+            "min": xs_sorted[0],
+            "p25": xs_sorted[n // 4],
+            "median": xs_sorted[n // 2],
+            "p75": xs_sorted[(3 * n) // 4],
+            "max": xs_sorted[-1],
+            "mean": sum(xs_sorted) / n,
+        }
+
+    return {
+        "conf": conf,
+        "year": year,
+        "n_papers": len(rows),
+        "status_breakdown": status_counter.most_common(),
+        "track_breakdown": track_counter.most_common(),
+        "rating_summary": _summary(ratings),
+        "citation_summary": _summary([float(c) for c in cites]),
+    }
+
+
+def top_papers(
+    conn: sqlite3.Connection,
+    *,
+    conf: str,
+    year: int,
+    by: str = "gs_citation",
+    top_k: int = 20,
+) -> dict:
+    by_col = {
+        "gs_citation": "gs_citation",
+        "rating": "rating_avg",
+        "rating_avg": "rating_avg",
+    }.get(by, "gs_citation")
+    rows = conn.execute(
+        f"""
+        SELECT conf, year, paper_id, title, authors, status, track, site,
+               openreview, rating_avg, gs_citation
+        FROM papers
+        WHERE conf=? AND year=? AND {by_col} IS NOT NULL
+        ORDER BY {by_col} DESC
+        LIMIT ?
+        """,
+        (conf.lower(), year, top_k),
+    ).fetchall()
+    return {"conf": conf, "year": year, "ranked_by": by_col, "results": rows}

--- a/tools/query-api/paperlists_api/queries.py
+++ b/tools/query-api/paperlists_api/queries.py
@@ -11,19 +11,117 @@ from collections import Counter
 from typing import Iterable, Optional
 
 EXCLUDED_STATUSES_DEFAULT = ("Withdraw", "Reject", "Withdrawn", "Rejected", "Desk Reject")
+_EXCLUDED_STATUSES_LOWER = tuple(s.lower() for s in EXCLUDED_STATUSES_DEFAULT)
 
-# FTS5 sanitizer.
-# - Strip characters that aren't word/space/quote.
-# - Treat hyphens as spaces (FTS5 reads `-token` as "NOT token", which breaks
-#   queries like "in-context learning"). Quoted hyphens are also fragile, so
-#   the safest behavior is plain whitespace AND.
-_FTS_BAD = re.compile(r"[^\w\s\"]+", flags=re.UNICODE)
+
+class FTSQueryError(ValueError):
+    """User query couldn't be parsed by FTS5. API layer maps this to HTTP 400."""
+
+
+# FTS5 input is treated as a *quoted phrase per token*, then AND-joined.
+# This neutralizes the FTS5 query language entirely: operators like AND/OR/NOT/
+# NEAR, prefix-NOT (`-foo`), column filters (`title:`), and unbalanced quotes
+# can no longer fall through and either change semantics or raise
+# sqlite3.OperationalError. The trade-off is that users lose FTS5 syntax —
+# acceptable for an agent-facing API where "search for these terms" is the
+# overwhelming dominant case.
+_FTS_KEEP = re.compile(r"[^\w\s]+", flags=re.UNICODE)
+
+
+def _fts_tokens(q: str) -> list[str]:
+    """Split user text into FTS5-safe tokens. Drops punctuation; hyphens
+    become whitespace so `in-context` doesn't read as the NOT-operator."""
+    if not q:
+        return []
+    cleaned = _FTS_KEEP.sub(" ", q.replace("-", " "))
+    return [t for t in cleaned.split() if t]
 
 
 def sanitize_fts(q: str) -> str:
-    q = (q or "").replace("-", " ")
-    q = _FTS_BAD.sub(" ", q)
-    return " ".join(q.split())
+    """Turn user text into a safe FTS5 expression.
+
+    Each token is wrapped in double quotes so FTS5 operators (AND/OR/NOT/NEAR,
+    column filters, `-`-prefix-NOT, prefix `*`) and unbalanced quotes can
+    never fall through. Tokens are joined by whitespace (FTS5 implicit AND).
+
+    **Trade-off:** documented FTS5 power features (`foo OR bar`,
+    `"exact phrase"`, `title:diffusion`, `reason*`) are NOT honored under
+    this default. Use `raw=True` on the endpoint to opt back in to full
+    FTS5 syntax (syntax errors then return HTTP 400).
+    """
+    return " ".join(f'"{t}"' for t in _fts_tokens(q))
+
+
+def sanitize_fts_phrase_in(column: str, q: str) -> str:
+    """Build an FTS5 column-scoped phrase: `column:"tok1 tok2"`. Used for
+    authors lookup where we want a single ordered phrase, not term-AND."""
+    tokens = _fts_tokens(q)
+    if not tokens:
+        return ""
+    return f'{column}:"{" ".join(tokens)}"'
+
+
+def _prepare_query(q: str, raw: bool) -> str:
+    """Map user input to an FTS5 expression. With `raw=True` we trust the
+    caller and let FTS5 parse the input as-is; the syntax-error → 400
+    mapping in `_run_fts` still keeps malformed input from 500'ing."""
+    if raw:
+        return (q or "").strip()
+    return sanitize_fts(q)
+
+
+# Known FTS5 parse-error fingerprints. Anything *not* in this set is a
+# server-side problem (missing table, locked db, schema drift, ...) and
+# should bubble up as 5xx rather than be mislabelled `invalid_query`.
+#
+# "no such column" looks server-side at first glance, but FTS5 emits it
+# when the user types a `bad_col:value` filter inside a raw MATCH — that's
+# a user parse error. We only honor this marker in raw mode (where users
+# can write column filters at all); in sanitized mode the sanitizer can
+# never produce a column-filter token, so a "no such column" there really
+# does indicate schema drift and should propagate.
+# Empirically derived by feeding bad input to FTS5; tests below pin the set.
+_FTS_PARSE_ERROR_MARKERS = (
+    "fts5: syntax error",          # AND/OR/NEAR misuse, unbalanced parens
+    "fts5: parse error",
+    "malformed match",
+    "unterminated string",         # unbalanced double-quote
+    "parse error",
+    "no such column",              # raw-mode `badcol:value` filter typo
+    "unknown special query",       # `*foo` and other special-query syntax errors
+    "fts5: unknown",               # variants of the above
+)
+
+
+def _run_fts(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: list,
+    *,
+    raw: bool = False,
+) -> list:
+    """Execute an FTS5-backed query.
+
+    When `raw=True` the caller passed user input verbatim into the MATCH
+    expression, so FTS5 parse errors are user-facing and we translate them
+    to FTSQueryError (HTTP 400 at the API layer). Any other sqlite error
+    (missing table, schema drift, db locked) propagates as-is so it
+    surfaces as a 5xx, not a misleading `invalid_query`.
+
+    When `raw=False` (default), the input was produced by `sanitize_fts`
+    which only emits quoted phrase tokens — that grammar is closed and
+    cannot fail. So we don't catch anything: if it fails, it's a server
+    bug and should be loud."""
+    try:
+        return conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as e:
+        if not raw:
+            raise
+        msg = str(e).lower()
+        if any(marker in msg for marker in _FTS_PARSE_ERROR_MARKERS):
+            raise FTSQueryError(str(e)) from e
+        # Looked like an operational/server error even in raw mode — leak it.
+        raise
 
 
 def _conf_filter(confs: Optional[list[str]]) -> tuple[str, list]:
@@ -46,11 +144,12 @@ def _year_filter(year_from: Optional[int], year_to: Optional[int]) -> tuple[str,
     return " AND " + " AND ".join(parts), params
 
 
-def _exclude_rejected_filter(exclude: bool) -> tuple[str, list]:
+def _exclude_rejected_filter(exclude: bool, *, alias: str = "p") -> tuple[str, list]:
     if not exclude:
         return "", []
-    placeholders = ",".join("?" * len(EXCLUDED_STATUSES_DEFAULT))
-    return f" AND (p.status IS NULL OR p.status NOT IN ({placeholders}))", list(EXCLUDED_STATUSES_DEFAULT)
+    placeholders = ",".join("?" * len(_EXCLUDED_STATUSES_LOWER))
+    col = f"{alias}.status" if alias else "status"
+    return f" AND ({col} IS NULL OR LOWER({col}) NOT IN ({placeholders}))", list(_EXCLUDED_STATUSES_LOWER)
 
 
 def _row_to_card(row: dict, *, include_abstract: bool) -> dict:
@@ -87,11 +186,23 @@ def search_papers(
     offset: int = 0,
     order_by: str = "relevance",
     include_abstract: bool = False,
+    raw: bool = False,
 ) -> dict:
-    """Full-text search across title/abstract/keywords/authors."""
-    q_clean = sanitize_fts(q)
+    """Full-text search across title/abstract/keywords/authors.
+
+    Default (`raw=False`): input is split into terms, each wrapped in
+    double quotes, AND'd together. Safe for arbitrary user input.
+
+    With `raw=True`: input is passed to FTS5 as-is, so callers can use
+    `foo OR bar`, `"exact phrase"`, `title:diffusion`, `reason*`. Malformed
+    expressions raise FTSQueryError (HTTP 400 at the API layer).
+    """
+    q_clean = _prepare_query(q, raw)
     if not q_clean:
-        return {"total": 0, "results": []}
+        return {
+            "total_matches": 0, "returned": 0, "offset": offset,
+            "limit": limit, "has_more": False, "total": 0, "results": [],
+        }
 
     conf_sql, conf_params = _conf_filter(conferences)
     year_sql, year_params = _year_filter(year_from, year_to)
@@ -114,7 +225,7 @@ def search_papers(
         LIMIT ? OFFSET ?
     """
     params = [q_clean, *conf_params, *year_params, *excl_params, limit, offset]
-    rows = conn.execute(sql, params).fetchall()
+    rows = _run_fts(conn, sql, params, raw=raw)
 
     count_sql = f"""
         SELECT COUNT(*) AS n
@@ -123,11 +234,19 @@ def search_papers(
         WHERE papers_fts MATCH ?
           {conf_sql}{year_sql}{excl_sql}
     """
-    total = conn.execute(count_sql, [q_clean, *conf_params, *year_params, *excl_params]).fetchone()["n"]
+    total = _run_fts(conn, count_sql, [q_clean, *conf_params, *year_params, *excl_params], raw=raw)[0]["n"]
 
+    cards = [_row_to_card(r, include_abstract=include_abstract) for r in rows]
     return {
+        # Primary, agent-friendly field name (matches the rest of the API).
+        "total_matches": total,
+        "returned": len(cards),
+        "offset": offset,
+        "limit": limit,
+        "has_more": (offset + len(cards)) < total,
+        # Back-compat alias — keep one release, then remove.
         "total": total,
-        "results": [_row_to_card(r, include_abstract=include_abstract) for r in rows],
+        "results": cards,
     }
 
 
@@ -173,9 +292,14 @@ def topic_trend(
     year_from: Optional[int] = None,
     year_to: Optional[int] = None,
     exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
-    """Yearly paper count + citation-weighted volume for a topic query."""
-    q_clean = sanitize_fts(q)
+    """Yearly paper count + citation-weighted volume for a topic query.
+
+    `raw=True` passes the query to FTS5 verbatim (full operator support);
+    default sanitizes input into AND'd quoted terms.
+    """
+    q_clean = _prepare_query(q, raw)
     if not q_clean:
         return {"query": q, "series": []}
 
@@ -197,7 +321,7 @@ def topic_trend(
         ORDER BY p.year, p.conf
     """
     params = [q_clean, *conf_params, *year_params, *excl_params]
-    rows = conn.execute(sql, params).fetchall()
+    rows = _run_fts(conn, sql, params, raw=raw)
 
     # Also yearly totals (any conference matching) for denominator/visualization.
     yearly: dict[int, dict] = {}
@@ -240,61 +364,120 @@ def topic_evolution(
     window: int = 1,
     top_k: int = 15,
     conferences: Optional[list[str]] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
     """Per-year (or per-window) top co-occurring keywords and top venues.
 
     For each year window, fetch papers matching `q` and aggregate keyword
     frequencies. Surfaces topic drift inside a research area.
+
+    `raw=True` enables full FTS5 syntax in the query (operators, prefix,
+    column filters); default sanitizes input.
     """
-    q_clean = sanitize_fts(q)
+    q_clean = _prepare_query(q, raw)
     if not q_clean or year_from > year_to:
         return {"query": q, "windows": []}
 
     conf_sql, conf_params = _conf_filter(conferences)
+    excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
+    sql = f"""
+        SELECT p.keywords AS keywords, p.conf AS conf, p.title AS title,
+               p.gs_citation AS cites, p.rating_avg AS rating, p.status AS status,
+               p.year AS year, p.paper_id AS paper_id
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ?
+          AND p.year BETWEEN ? AND ?
+          {conf_sql}{excl_sql}
+    """
+    rows = _run_fts(conn, sql, [q_clean, year_from, year_to, *conf_params, *excl_params], raw=raw)
 
-    windows = []
+    buckets: dict[int, dict] = {}
     y = year_from
     while y <= year_to:
         w_end = min(y + window - 1, year_to)
-        sql = f"""
-            SELECT p.keywords AS keywords, p.conf AS conf, p.title AS title,
-                   p.gs_citation AS cites, p.year AS year, p.paper_id AS paper_id
-            FROM papers_fts
-            JOIN papers p ON p.id = papers_fts.rowid
-            WHERE papers_fts MATCH ?
-              AND p.year BETWEEN ? AND ?
-              {conf_sql}
-        """
-        rows = conn.execute(sql, [q_clean, y, w_end, *conf_params]).fetchall()
-
-        kw_counter: Counter[str] = Counter()
-        conf_counter: Counter[str] = Counter()
-        for r in rows:
-            for kw in _tokenize_keywords(r["keywords"]):
-                kw_counter[kw] += 1
-            if r["conf"]:
-                conf_counter[r["conf"]] += 1
-
-        # Surface top-cited paper of the window as a "landmark".
-        landmarks = sorted(
-            [r for r in rows if r["cites"]],
-            key=lambda r: r["cites"] or 0,
-            reverse=True,
-        )[:5]
-
-        windows.append({
+        buckets[y] = {
             "year_from": y,
             "year_to": w_end,
-            "n_papers": len(rows),
-            "top_keywords": kw_counter.most_common(top_k),
-            "top_venues": conf_counter.most_common(10),
+            "n_papers": 0,
+            "keywords": Counter(),
+            "venues": Counter(),
+            "candidates": [],
+            "max_cite": 0,
+        }
+        y = w_end + 1
+
+    # Status weight: prefer accepted-with-distinction → poster → unknown.
+    _STATUS_BONUS = {
+        "oral": 3.0, "spotlight": 2.0, "poster": 1.0,
+        "accept": 1.0, "accepted": 1.0,
+    }
+
+    for r in rows:
+        start = year_from + ((r["year"] - year_from) // window) * window
+        bucket = buckets[start]
+        bucket["n_papers"] += 1
+        for kw in _tokenize_keywords(r["keywords"]):
+            bucket["keywords"][kw] += 1
+        if r["conf"]:
+            bucket["venues"][r["conf"]] += 1
+        # Track every candidate; rank later with a citation-or-rating blend.
+        bucket["candidates"].append(r)
+        if (r["cites"] or 0) > bucket["max_cite"]:
+            bucket["max_cite"] = r["cites"] or 0
+
+    def _row_features(row: dict) -> tuple:
+        cite = row["cites"] or 0
+        rating = row["rating"] or 0.0
+        status = (row["status"] or "").lower()
+        bonus = _STATUS_BONUS.get(status, 0.0)
+        return cite, rating, bonus
+
+    def _key_by_citation(row: dict) -> tuple:
+        cite, rating, bonus = _row_features(row)
+        return (cite, rating, bonus)
+
+    def _key_by_rating(row: dict) -> tuple:
+        # In the fallback regime ratings + acceptance bonus dominate. We
+        # still include citation as the deepest tiebreaker so 1-cite vs
+        # 0-cite among otherwise-identical papers stays deterministic.
+        cite, rating, bonus = _row_features(row)
+        return (bonus, rating, cite)
+
+    windows = []
+    for y in sorted(buckets):
+        bucket = buckets[y]
+        # Citation-only is unfair for the current year (papers <1 year old have
+        # near-zero gs_citation). When the window's max citation is low, the
+        # landmark ranking degenerates to "earliest-published venue wins" —
+        # one weak paper with a single cite would beat a strong Spotlight
+        # with 0 cites. Switch to a rating-and-status sort in that regime.
+        if bucket["max_cite"] >= 20:
+            ranking_basis = "gs_citation"
+            key_fn = _key_by_citation
+        else:
+            ranking_basis = "rating_avg+status_fallback"
+            key_fn = _key_by_rating
+        landmarks = sorted(bucket["candidates"], key=key_fn, reverse=True)[:5]
+        windows.append({
+            "year_from": bucket["year_from"],
+            "year_to": bucket["year_to"],
+            "n_papers": bucket["n_papers"],
+            "ranking_basis": ranking_basis,
+            "top_keywords": bucket["keywords"].most_common(top_k),
+            "top_venues": bucket["venues"].most_common(10),
             "landmark_papers": [
-                {"conf": r["conf"], "year": r["year"], "paper_id": r["paper_id"],
-                 "title": r["title"], "gs_citation": r["cites"]}
+                {
+                    "conf": r["conf"], "year": r["year"], "paper_id": r["paper_id"],
+                    "title": r["title"],
+                    "gs_citation": r["cites"],
+                    "rating_avg": r["rating"],
+                    "status": r["status"],
+                }
                 for r in landmarks
             ],
         })
-        y = w_end + 1
 
     return {"query": q, "window": window, "windows": windows}
 
@@ -311,7 +494,9 @@ def author_trajectory(
         return {"name": name, "by_year": []}
 
     # We match against the `authors` FTS column as an exact-phrase token.
-    q_phrase = f'authors:"{sanitize_fts(name)}"'
+    q_phrase = sanitize_fts_phrase_in("authors", name)
+    if not q_phrase:
+        return {"name": name, "total_papers": 0, "by_year": []}
     year_sql, year_params = _year_filter(year_from, year_to)
     sql = f"""
         SELECT p.year, p.conf, p.paper_id, p.title, p.authors, p.gs_citation, p.status
@@ -321,7 +506,7 @@ def author_trajectory(
           {year_sql}
         ORDER BY p.year DESC, p.gs_citation DESC NULLS LAST
     """
-    rows = conn.execute(sql, [q_phrase, *year_params]).fetchall()
+    rows = _run_fts(conn, sql, [q_phrase, *year_params])
 
     by_year: dict[int, list] = {}
     for r in rows:
@@ -348,23 +533,33 @@ def field_landscape(
     q: str,
     year: int,
     top_k: int = 10,
+    conferences: Optional[list[str]] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
     """Single-year snapshot for a field: top papers, top authors, top affiliations,
-    top keywords. Useful for 'state of <field> in <year>' summaries."""
-    q_clean = sanitize_fts(q)
+    top keywords. Useful for 'state of <field> in <year>' summaries.
+
+    `raw=True` enables full FTS5 syntax."""
+    q_clean = _prepare_query(q, raw)
     if not q_clean:
         return {"query": q, "year": year}
 
-    rows = conn.execute(
-        """
+    conf_sql, conf_params = _conf_filter(conferences)
+    excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
+    rows = _run_fts(
+        conn,
+        f"""
         SELECT p.conf, p.year, p.paper_id, p.title, p.authors, p.affiliations,
                p.keywords, p.gs_citation, p.rating_avg, p.status, p.openreview, p.site
         FROM papers_fts
         JOIN papers p ON p.id = papers_fts.rowid
         WHERE papers_fts MATCH ? AND p.year = ?
+          {conf_sql}{excl_sql}
         """,
-        [q_clean, year],
-    ).fetchall()
+        [q_clean, year, *conf_params, *excl_params],
+        raw=raw,
+    )
 
     author_counter: Counter[str] = Counter()
     aff_counter: Counter[str] = Counter()
@@ -412,38 +607,77 @@ def compare_periods(
     period_a: tuple[int, int],
     period_b: tuple[int, int],
     top_k: int = 15,
+    conferences: Optional[list[str]] = None,
+    exclude_rejected: bool = True,
+    raw: bool = False,
 ) -> dict:
     """Diff a topic between two year ranges. Returns keywords/authors/affiliations
-    that emerged, disappeared, or stayed across the two periods."""
-    def _bucket(years: tuple[int, int]) -> dict:
-        q_clean = sanitize_fts(q)
-        rows = conn.execute(
-            """
-            SELECT p.authors, p.affiliations, p.keywords, p.title, p.paper_id, p.conf, p.year, p.gs_citation
-            FROM papers_fts
-            JOIN papers p ON p.id = papers_fts.rowid
-            WHERE papers_fts MATCH ? AND p.year BETWEEN ? AND ?
-            """,
-            [q_clean, years[0], years[1]],
-        ).fetchall()
-        authors: Counter[str] = Counter()
-        affs: Counter[str] = Counter()
-        kws: Counter[str] = Counter()
-        for r in rows:
-            for a in (r["authors"] or "").split(";"):
-                a = a.strip()
-                if a:
-                    authors[a] += 1
-            for af in (r["affiliations"] or "").split(";"):
-                af = af.strip()
-                if af:
-                    affs[af] += 1
-            for kw in _tokenize_keywords(r["keywords"]):
-                kws[kw] += 1
-        return {"n_papers": len(rows), "authors": authors, "affiliations": affs, "keywords": kws}
+    that emerged, disappeared, or stayed across the two periods.
 
-    a = _bucket(period_a)
-    b = _bucket(period_b)
+    `raw=True` enables full FTS5 syntax."""
+    def _period_meta(p: tuple[int, int], n: int) -> dict:
+        # Expose both shapes so clients can use either `years[0]/[1]` or
+        # the flat `year_from`/`year_to` form.
+        return {
+            "years": list(p),
+            "year_from": p[0],
+            "year_to": p[1],
+            "n_papers": n,
+        }
+
+    q_clean = _prepare_query(q, raw)
+    if not q_clean:
+        empty = {"emerged": [], "faded": [], "sustained": []}
+        return {
+            "query": q,
+            "period_a": _period_meta(period_a, 0),
+            "period_b": _period_meta(period_b, 0),
+            "keyword_diff": empty,
+            "author_diff": empty,
+            "affiliation_diff": empty,
+        }
+
+    lo = min(period_a[0], period_b[0])
+    hi = max(period_a[1], period_b[1])
+    conf_sql, conf_params = _conf_filter(conferences)
+    excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected)
+    rows = _run_fts(
+        conn,
+        f"""
+        SELECT p.authors, p.affiliations, p.keywords, p.year
+        FROM papers_fts
+        JOIN papers p ON p.id = papers_fts.rowid
+        WHERE papers_fts MATCH ? AND p.year BETWEEN ? AND ?
+          {conf_sql}{excl_sql}
+        """,
+        [q_clean, lo, hi, *conf_params, *excl_params],
+        raw=raw,
+    )
+
+    def _empty_bucket() -> dict:
+        return {"n_papers": 0, "authors": Counter(), "affiliations": Counter(), "keywords": Counter()}
+
+    a = _empty_bucket()
+    b = _empty_bucket()
+
+    def _add(bucket: dict, r: dict) -> None:
+        bucket["n_papers"] += 1
+        for author in (r["authors"] or "").split(";"):
+            author = author.strip()
+            if author:
+                bucket["authors"][author] += 1
+        for aff in (r["affiliations"] or "").split(";"):
+            aff = aff.strip()
+            if aff:
+                bucket["affiliations"][aff] += 1
+        for kw in _tokenize_keywords(r["keywords"]):
+            bucket["keywords"][kw] += 1
+
+    for r in rows:
+        if period_a[0] <= r["year"] <= period_a[1]:
+            _add(a, r)
+        if period_b[0] <= r["year"] <= period_b[1]:
+            _add(b, r)
 
     def _diff(ca: Counter, cb: Counter, k: int):
         emerged = [(x, cb[x]) for x in cb if x not in ca]
@@ -460,8 +694,8 @@ def compare_periods(
 
     return {
         "query": q,
-        "period_a": {"years": period_a, "n_papers": a["n_papers"]},
-        "period_b": {"years": period_b, "n_papers": b["n_papers"]},
+        "period_a": _period_meta(period_a, a["n_papers"]),
+        "period_b": _period_meta(period_b, b["n_papers"]),
         "keyword_diff": _diff(a["keywords"], b["keywords"], top_k),
         "author_diff": _diff(a["authors"], b["authors"], top_k),
         "affiliation_diff": _diff(a["affiliations"], b["affiliations"], top_k),
@@ -518,21 +752,30 @@ def top_papers(
     year: int,
     by: str = "gs_citation",
     top_k: int = 20,
+    exclude_rejected: bool = True,
 ) -> dict:
     by_col = {
         "gs_citation": "gs_citation",
         "rating": "rating_avg",
         "rating_avg": "rating_avg",
     }.get(by, "gs_citation")
+    excl_sql, excl_params = _exclude_rejected_filter(exclude_rejected, alias="")
     rows = conn.execute(
         f"""
         SELECT conf, year, paper_id, title, authors, status, track, site,
                openreview, rating_avg, gs_citation
         FROM papers
         WHERE conf=? AND year=? AND {by_col} IS NOT NULL
+          {excl_sql}
         ORDER BY {by_col} DESC
         LIMIT ?
         """,
-        (conf.lower(), year, top_k),
+        (conf.lower(), year, *excl_params, top_k),
     ).fetchall()
-    return {"conf": conf, "year": year, "ranked_by": by_col, "results": rows}
+    return {
+        "conf": conf,
+        "year": year,
+        "ranked_by": by_col,
+        "exclude_rejected": exclude_rejected,
+        "results": [dict(r) for r in rows],
+    }

--- a/tools/query-api/paperlists_api/ratelimit.py
+++ b/tools/query-api/paperlists_api/ratelimit.py
@@ -1,0 +1,143 @@
+"""Cross-worker rate limiter backed by a tiny sqlite file.
+
+The query API's main `papers.db` is opened immutable in production, so we
+keep the bucket state in a separate writable sqlite file. All uvicorn
+workers see the same bucket for the same client IP, which is the whole
+point — an in-memory bucket per worker would be 4× too generous on a
+4-worker deployment and would let an attacker rotate workers to bypass
+the limit.
+
+Token-bucket semantics:
+- `tokens` accumulate at PAPERLISTS_RATE_PER_MIN/60.0 per second
+- Each accepted request consumes 1 token
+- Bursts are capped at PAPERLISTS_RATE_BURST
+- Stale rows (last_seen > PAPERLISTS_RATE_STALE_SEC ago) are GC'd
+  opportunistically on every Nth call
+- Hard cap of PAPERLISTS_RATE_BUCKET_MAX rows; oldest evicted first
+
+The implementation is intentionally simple — one SELECT, one UPSERT per
+request, all in a single WAL-mode db. At ~60 req/min/IP this is well
+under the cost of the actual FTS5 query that follows.
+"""
+from __future__ import annotations
+
+import os
+import random
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+RATE_DB_PATH = Path(
+    os.environ.get("PAPERLISTS_RATELIMIT_DB", "/tmp/paperlists-ratelimit.db")
+).resolve()
+RATE_PER_MIN = float(os.environ.get("PAPERLISTS_RATE_PER_MIN", "60"))
+RATE_BURST = float(os.environ.get("PAPERLISTS_RATE_BURST", "20"))
+BUCKET_MAX = int(os.environ.get("PAPERLISTS_RATE_BUCKET_MAX", "10000"))
+STALE_SEC = float(os.environ.get("PAPERLISTS_RATE_STALE_SEC", str(60 * 30)))
+GC_PROBABILITY = float(os.environ.get("PAPERLISTS_RATE_GC_PROBABILITY", "0.01"))
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS rate_buckets (
+    ip         TEXT PRIMARY KEY,
+    tokens     REAL NOT NULL,
+    last_seen  REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_rate_last_seen ON rate_buckets(last_seen);
+"""
+
+# Per-worker connection. sqlite3 connections aren't thread-safe by default
+# but FastAPI's threadpool may call us from multiple threads; we serialize
+# inside the process via a lock and rely on WAL + IMMEDIATE for cross-
+# worker safety.
+_lock = threading.Lock()
+_conn: sqlite3.Connection | None = None
+
+
+def _ensure_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is not None:
+        return _conn
+    RATE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(RATE_DB_PATH, timeout=2.0, isolation_level=None, check_same_thread=False)
+    conn.executescript("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA busy_timeout=2000;")
+    conn.executescript(_SCHEMA)
+    _conn = conn
+    return conn
+
+
+def _maybe_gc(conn: sqlite3.Connection, now: float) -> None:
+    """Opportunistically drop stale + over-cap rows. Cheap on the median
+    request because we only run with probability GC_PROBABILITY."""
+    if random.random() > GC_PROBABILITY:
+        return
+    conn.execute("DELETE FROM rate_buckets WHERE last_seen < ?", (now - STALE_SEC,))
+    n = conn.execute("SELECT COUNT(*) FROM rate_buckets").fetchone()[0]
+    if n > BUCKET_MAX:
+        # Drop the oldest (n - BUCKET_MAX) rows.
+        conn.execute(
+            "DELETE FROM rate_buckets WHERE ip IN ("
+            "  SELECT ip FROM rate_buckets ORDER BY last_seen ASC LIMIT ?"
+            ")",
+            (n - BUCKET_MAX,),
+        )
+
+
+def check_and_consume(ip: str) -> tuple[bool, int]:
+    """Return (allowed, retry_after_sec). retry_after_sec is meaningful
+    only when allowed=False."""
+    now = time.time()
+    with _lock:
+        conn = _ensure_conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError:
+            # Couldn't grab the writer lock in time — fail open rather than
+            # crash; the limiter is a soft guardrail, not a hard barrier.
+            return True, 0
+        try:
+            row = conn.execute(
+                "SELECT tokens, last_seen FROM rate_buckets WHERE ip=?", (ip,)
+            ).fetchone()
+            if row is None:
+                tokens, last = RATE_BURST, now
+            else:
+                tokens, last = row
+                tokens = min(RATE_BURST, tokens + (now - last) * (RATE_PER_MIN / 60.0))
+
+            if tokens < 1.0:
+                # Persist the refilled-but-still-insufficient state so the
+                # client doesn't keep "starting fresh" by spacing requests.
+                conn.execute(
+                    "INSERT INTO rate_buckets(ip, tokens, last_seen) VALUES(?,?,?) "
+                    "ON CONFLICT(ip) DO UPDATE SET tokens=excluded.tokens, last_seen=excluded.last_seen",
+                    (ip, tokens, now),
+                )
+                conn.execute("COMMIT")
+                retry = int((1.0 - tokens) * 60.0 / RATE_PER_MIN) + 1
+                return False, retry
+
+            conn.execute(
+                "INSERT INTO rate_buckets(ip, tokens, last_seen) VALUES(?,?,?) "
+                "ON CONFLICT(ip) DO UPDATE SET tokens=excluded.tokens, last_seen=excluded.last_seen",
+                (ip, tokens - 1.0, now),
+            )
+            _maybe_gc(conn, now)
+            conn.execute("COMMIT")
+            return True, 0
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+
+def reset_for_tests() -> None:
+    """Test helper: drop all bucket state."""
+    global _conn
+    with _lock:
+        if _conn is not None:
+            _conn.close()
+            _conn = None
+        try:
+            RATE_DB_PATH.unlink()
+        except FileNotFoundError:
+            pass

--- a/tools/query-api/pyproject.toml
+++ b/tools/query-api/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "paperlists-api"
+version = "0.1.0"
+description = "Hosted query API over the papercopilot/paperlists corpus."
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "orjson>=3.9",
+]
+
+[project.optional-dependencies]
+dev = ["httpx>=0.27", "pytest>=8.0"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["paperlists_api*"]

--- a/tools/query-api/railway.json
+++ b/tools/query-api/railway.json
@@ -2,10 +2,10 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "tools/query-api/Dockerfile"
+    "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "uvicorn paperlists_api.main:app --host 0.0.0.0 --port $PORT",
+    "startCommand": "sh -c \"uvicorn paperlists_api.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-4}\"",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3,
     "healthcheckPath": "/healthz",

--- a/tools/query-api/railway.json
+++ b/tools/query-api/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "tools/query-api/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "uvicorn paperlists_api.main:app --host 0.0.0.0 --port $PORT",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3,
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 30
+  }
+}

--- a/tools/query-api/tests/test_fixes_from_codex_review.py
+++ b/tools/query-api/tests/test_fixes_from_codex_review.py
@@ -1,0 +1,456 @@
+"""Regression tests for the fixes from the codex review pass.
+
+Each test pins a specific finding so a future refactor can't silently
+un-fix it.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from paperlists_api import queries
+from paperlists_api.indexer import build_index
+
+
+def _write_json(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(rows), encoding="utf-8")
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------- P1: indexer dedup ----------
+
+def test_indexer_dedup_keeps_distinct_records_with_colliding_id(tmp_path: Path) -> None:
+    """codex P1: siggraph2025.json has the same `id` for 4-5 paper rows.
+    The original UNIQUE(conf, year, paper_id) + INSERT OR IGNORE silently
+    dropped them. We now generate a sha1 fallback per collision."""
+    _write_json(
+        tmp_path / "siggraph" / "siggraph2025.json",
+        [
+            {"id": "shared-id", "title": "Paper A", "author": "Alice"},
+            {"id": "shared-id", "title": "Paper B", "author": "Bob"},
+            {"id": "shared-id", "title": "Paper C", "author": "Carol"},
+            {"id": "unique-id", "title": "Paper D", "author": "Dave"},
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        # All 4 distinct papers must be indexed.
+        rows = conn.execute("SELECT title, paper_id FROM papers ORDER BY title").fetchall()
+        titles = [r["title"] for r in rows]
+        assert titles == ["Paper A", "Paper B", "Paper C", "Paper D"]
+        # The fallback rekeyed at least 2 of the 3 colliding records. It may
+        # use a later stable ID candidate (doi/openreview/...) or a generated
+        # hash when no stable alternate exists.
+        rekeyed = [r["paper_id"] for r in rows if r["paper_id"] != "shared-id"]
+        assert len(rekeyed) >= 3
+        assert len({r["paper_id"] for r in rows}) == 4
+        # No empty paper_ids.
+        for r in rows:
+            assert r["paper_id"] and r["paper_id"].strip()
+
+
+# ---------- P2: FTS5 sanitizer ----------
+
+@pytest.mark.parametrize("bad_query", [
+    "foo AND NOT bar",            # bare FTS5 operators
+    'unclosed"quote',             # unbalanced double-quote
+    "in-context learning",        # leading `-` would parse as NOT
+    "LLM-reasoning",
+    "-exclude this",
+    "NEAR(foo bar)",
+    'title:"injection"',          # column-scoped phrase injection
+])
+def test_sanitize_fts_neutralizes_dangerous_inputs(tmp_path: Path, bad_query: str) -> None:
+    """codex P2: previously these inputs raised sqlite3.OperationalError →
+    HTTP 500. Now they should either match zero results or match legitimate
+    terms, but never raise."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "x", "title": "foo bar baz", "keywords": "test", "status": "Poster"}],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        # Should not raise. The result count is allowed to be anything ≥ 0.
+        out = queries.search_papers(conn, q=bad_query)
+        assert "total_matches" in out
+        assert out["total_matches"] >= 0
+
+
+# ---------- P2: search response shape ----------
+
+def test_search_returns_total_matches_and_pagination_metadata(tmp_path: Path) -> None:
+    """codex P2: clients can't paginate without total_matches; the field
+    was previously named `total`. Keep `total` as a back-compat alias."""
+    rows = [
+        {"id": f"p{i}", "title": f"reasoning paper {i}", "keywords": "reasoning", "status": "Poster"}
+        for i in range(7)
+    ]
+    _write_json(tmp_path / "iclr" / "iclr2025.json", rows)
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        out = queries.search_papers(conn, q="reasoning", limit=3, offset=0)
+        assert out["total_matches"] == 7
+        assert out["total"] == 7  # alias for one release
+        assert out["returned"] == 3
+        assert out["limit"] == 3
+        assert out["offset"] == 0
+        assert out["has_more"] is True
+
+        out2 = queries.search_papers(conn, q="reasoning", limit=10, offset=0)
+        assert out2["has_more"] is False
+
+
+# ---------- P2: compare_periods schema ----------
+
+def test_compare_periods_exposes_flat_year_fields(tmp_path: Path) -> None:
+    """codex P2 + my own flag: clients expect period_a.year_from /
+    period_a.year_to; previously only `years: [a, b]` was emitted."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2023.json",
+        [{"id": "a", "title": "reasoning", "keywords": "reasoning", "status": "Poster"}],
+    )
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "b", "title": "reasoning", "keywords": "reasoning", "status": "Poster"}],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        out = queries.compare_periods(
+            conn, q="reasoning",
+            period_a=(2023, 2023),
+            period_b=(2025, 2025),
+        )
+        for k in ("years", "year_from", "year_to", "n_papers"):
+            assert k in out["period_a"], f"period_a missing {k}"
+            assert k in out["period_b"], f"period_b missing {k}"
+        assert out["period_a"]["year_from"] == 2023
+        assert out["period_a"]["year_to"] == 2023
+        assert out["period_b"]["year_from"] == 2025
+        assert out["period_b"]["year_to"] == 2025
+
+
+# ---------- P2: landmark fallback ----------
+
+def test_topic_evolution_landmark_fallback_when_citations_sparse(tmp_path: Path) -> None:
+    """codex P2: current-year papers have ~0 citations, so filtering by
+    `if r['cites']` strips them. We now switch to rating_avg + status."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [
+            {
+                "id": "spotlight-paper", "title": "Spotlight reasoning paper",
+                "keywords": "reasoning", "status": "Spotlight",
+                "rating_avg": 8.0, "gs_citation": 0,
+            },
+            {
+                "id": "poster-paper", "title": "Poster reasoning paper",
+                "keywords": "reasoning", "status": "Poster",
+                "rating_avg": 6.0, "gs_citation": None,
+            },
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        out = queries.topic_evolution(
+            conn, q="reasoning", year_from=2025, year_to=2025, window=1,
+        )
+        assert len(out["windows"]) == 1
+        w = out["windows"][0]
+        # Must surface BOTH papers (old code would have shown 0 landmarks).
+        titles = [p["title"] for p in w["landmark_papers"]]
+        assert "Spotlight reasoning paper" in titles
+        assert "Poster reasoning paper" in titles
+        # Higher-rating Spotlight should rank above lower-rating Poster.
+        assert titles[0] == "Spotlight reasoning paper"
+        # Caller can see WHY the ranking was chosen.
+        assert w["ranking_basis"] == "rating_avg+status_fallback"
+
+
+# ---------- P1: top_papers exclude_rejected ----------
+
+# ---------- Round 2 (codex re-review) ----------
+
+def test_landmark_fallback_actually_demotes_low_cite_paper(tmp_path: Path) -> None:
+    """codex round-2 P2a: previous fix reported `ranking_basis: rating_avg+
+    status_fallback` but still sorted by `(cite, rating, bonus)` — so a 1-cite
+    weak paper still beat a 0-cite Spotlight. The sort key must actually
+    change in the fallback regime."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [
+            {
+                "id": "weak-but-cited",
+                "title": "Weak paper with one citation",
+                "keywords": "reasoning",
+                "status": "Poster",
+                "rating_avg": 3.0,
+                "gs_citation": 1,
+            },
+            {
+                "id": "strong-spotlight",
+                "title": "Strong Spotlight reasoning paper",
+                "keywords": "reasoning",
+                "status": "Spotlight",
+                "rating_avg": 8.0,
+                "gs_citation": 0,
+            },
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        out = queries.topic_evolution(
+            conn, q="reasoning", year_from=2025, year_to=2025, window=1,
+        )
+        w = out["windows"][0]
+        assert w["ranking_basis"] == "rating_avg+status_fallback"
+        # The Spotlight must rank first despite 0 citations.
+        assert w["landmark_papers"][0]["title"] == "Strong Spotlight reasoning paper"
+        assert w["landmark_papers"][1]["title"] == "Weak paper with one citation"
+
+
+def test_landmark_uses_citation_sort_above_threshold(tmp_path: Path) -> None:
+    """Symmetric check: when max_cite >= 20, citation ordering wins even
+    against higher-rated papers."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2024.json",
+        [
+            {
+                "id": "cited-classic",
+                "title": "Cited classic",
+                "keywords": "reasoning",
+                "status": "Poster",
+                "rating_avg": 5.0,
+                "gs_citation": 500,
+            },
+            {
+                "id": "fresh-spotlight",
+                "title": "Fresh Spotlight",
+                "keywords": "reasoning",
+                "status": "Spotlight",
+                "rating_avg": 9.0,
+                "gs_citation": 5,
+            },
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        out = queries.topic_evolution(
+            conn, q="reasoning", year_from=2024, year_to=2024, window=1,
+        )
+        w = out["windows"][0]
+        assert w["ranking_basis"] == "gs_citation"
+        assert w["landmark_papers"][0]["title"] == "Cited classic"
+
+
+def test_raw_mode_enables_fts5_operators(tmp_path: Path) -> None:
+    """codex round-2 P2b: with `raw=False` (default) FTS5 operators like
+    OR and column filters are treated as literal tokens. With `raw=True`
+    they regain their FTS5 meaning."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [
+            {"id": "a", "title": "diffusion model", "status": "Poster"},
+            {"id": "b", "title": "transformer model", "status": "Poster"},
+            {"id": "c", "title": "completely unrelated graph paper", "status": "Poster"},
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        # Default sanitizer: "diffusion OR transformer" is AND'd as 3 terms,
+        # so only papers containing all three words (none) match.
+        default_out = queries.search_papers(conn, q="diffusion OR transformer")
+        assert default_out["total_matches"] == 0
+
+        # raw=True: FTS5 parses OR as the boolean operator, returning both.
+        raw_out = queries.search_papers(conn, q="diffusion OR transformer", raw=True)
+        assert raw_out["total_matches"] == 2
+        titles = {r["title"] for r in raw_out["results"]}
+        assert titles == {"diffusion model", "transformer model"}
+
+
+def test_raw_mode_malformed_query_raises_typed_error(tmp_path: Path) -> None:
+    """raw=True with malformed input should raise FTSQueryError (HTTP 400 at
+    the API layer), not a generic 500."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "a", "title": "diffusion model", "status": "Poster"}],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        with pytest.raises(queries.FTSQueryError):
+            queries.search_papers(conn, q='unclosed"phrase', raw=True)
+
+
+@pytest.mark.parametrize("bad_raw_query", [
+    'badcol:diffusion',       # column-filter typo → "no such column"
+    'foo -bar',                # leading-`-` operator → "no such column: bar"
+    '*foo',                    # bad special query → "unknown special query"
+    '"unclosed',               # unbalanced quote → "unterminated string"
+    'AND foo',                 # bare operator → "fts5: syntax error"
+    '(unbalanced',             # unbalanced paren → "fts5: syntax error"
+    'OR bar',
+])
+def test_raw_mode_classifies_known_fts5_parse_errors_as_400(tmp_path: Path, bad_raw_query: str) -> None:
+    """codex round-4 P2: parse-error marker list must cover everything
+    FTS5 actually emits for malformed user input — not just the obvious
+    `fts5: syntax error`. Otherwise raw=true bad queries 500."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "a", "title": "diffusion model", "status": "Poster"}],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        with pytest.raises(queries.FTSQueryError):
+            queries.search_papers(conn, q=bad_raw_query, raw=True)
+
+
+def test_proxy_auto_detection_covers_major_platforms(monkeypatch) -> None:
+    """codex round-4 P3: auto-detect should fire for Railway, HF Spaces,
+    Fly, Render, Vercel, Cloud Run, Azure App Service."""
+    import importlib
+    from paperlists_api import main as m
+    for env_var in [
+        "RAILWAY_ENVIRONMENT", "SPACE_ID", "FLY_APP_NAME",
+        "RENDER", "VERCEL", "K_SERVICE", "WEBSITE_SITE_NAME",
+    ]:
+        # Clean state.
+        for v in m._PLATFORM_PROXY_MARKERS:
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.delenv("PAPERLISTS_TRUST_PROXY", raising=False)
+        monkeypatch.setenv(env_var, "1")
+        importlib.reload(m)
+        assert m._TRUST_PROXY, f"{env_var} should auto-enable trust_proxy"
+        assert m._DETECTED_PROXY_NAME == env_var
+
+
+def test_proxy_explicit_off_overrides_auto_detection(monkeypatch) -> None:
+    """If the operator sets PAPERLISTS_TRUST_PROXY=0, auto-detect must
+    not re-enable it. Otherwise the explicit safety opt-out is broken."""
+    import importlib
+    from paperlists_api import main as m
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT", "production")
+    monkeypatch.setenv("PAPERLISTS_TRUST_PROXY", "0")
+    importlib.reload(m)
+    assert not m._TRUST_PROXY
+
+
+def test_server_errors_dont_masquerade_as_invalid_query(tmp_path: Path) -> None:
+    """codex round-3 P3: previously, ANY sqlite OperationalError in _run_fts
+    was mapped to FTSQueryError → HTTP 400 invalid_query. If the FTS table
+    went missing post-deploy, a 5xx-worthy bug would be hidden as a 400.
+    Now: in default (sanitized) mode, errors propagate as-is."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "a", "title": "diffusion model", "status": "Poster"}],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        # Simulate schema drift by dropping the FTS table.
+        conn.execute("DROP TABLE papers_fts")
+        # Default-mode query against a broken DB should leak the real
+        # error, not be relabelled as user input invalid.
+        with pytest.raises(sqlite3.OperationalError):
+            queries.search_papers(conn, q="diffusion")
+
+
+def test_ratelimit_db_state_shared_across_invocations(tmp_path: Path) -> None:
+    """codex round-2 P1a: the rate-limit bucket must be sqlite-backed so
+    multiple uvicorn workers see the same state. We can't fork workers in
+    a unit test, but we can prove the state lives in a sqlite file by
+    closing the connection between calls and observing token consumption
+    persists."""
+    import os, importlib
+    db_path = tmp_path / "rl.db"
+    os.environ["PAPERLISTS_RATELIMIT_DB"] = str(db_path)
+    os.environ["PAPERLISTS_RATE_PER_MIN"] = "60"
+    os.environ["PAPERLISTS_RATE_BURST"] = "3"
+    try:
+        # Re-import so the module picks up the env override.
+        from paperlists_api import ratelimit as rl
+        importlib.reload(rl)
+        rl.reset_for_tests()
+        # 3 requests should pass.
+        for _ in range(3):
+            allowed, _ = rl.check_and_consume("1.2.3.4")
+            assert allowed
+        # 4th should fail.
+        allowed, retry = rl.check_and_consume("1.2.3.4")
+        assert not allowed
+        assert retry >= 1
+
+        # Simulate worker restart by closing the connection and re-opening.
+        # State should persist (the sqlite file is the source of truth).
+        if rl._conn is not None:
+            rl._conn.close()
+            rl._conn = None
+        allowed, _ = rl.check_and_consume("1.2.3.4")
+        assert not allowed, "bucket state must survive a worker restart"
+    finally:
+        os.environ.pop("PAPERLISTS_RATELIMIT_DB", None)
+        os.environ.pop("PAPERLISTS_RATE_PER_MIN", None)
+        os.environ.pop("PAPERLISTS_RATE_BURST", None)
+
+
+def test_top_papers_excludes_rejected_by_default(tmp_path: Path) -> None:
+    """codex P1: top_papers had no exclude_rejected filter. For OpenReview
+    venues, Reject papers can have high gs_citation and pollute the ranking."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [
+            {
+                "id": "rejected-but-cited",
+                "title": "Rejected but cited",
+                "status": "Reject", "gs_citation": 500,
+            },
+            {
+                "id": "accepted",
+                "title": "Accepted poster",
+                "status": "Poster", "gs_citation": 100,
+            },
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        out = queries.top_papers(conn, conf="iclr", year=2025, by="gs_citation")
+        titles = [r["title"] for r in out["results"]]
+        assert titles == ["Accepted poster"]
+        assert out["exclude_rejected"] is True
+
+        out_raw = queries.top_papers(
+            conn, conf="iclr", year=2025, by="gs_citation", exclude_rejected=False,
+        )
+        titles_raw = [r["title"] for r in out_raw["results"]]
+        assert titles_raw == ["Rejected but cited", "Accepted poster"]

--- a/tools/query-api/tests/test_fixes_from_codex_review.py
+++ b/tools/query-api/tests/test_fixes_from_codex_review.py
@@ -333,6 +333,31 @@ def test_raw_mode_classifies_known_fts5_parse_errors_as_400(tmp_path: Path, bad_
             queries.search_papers(conn, q=bad_raw_query, raw=True)
 
 
+def test_raw_mode_no_such_column_schema_errors_still_propagate(tmp_path: Path) -> None:
+    """`no such column` can come from FTS syntax or from real SQL drift. Dotted
+    SQL column names should not be relabelled as user-invalid FTS input."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "a", "title": "diffusion model", "status": "Poster"}],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        with pytest.raises(sqlite3.OperationalError, match="no such column"):
+            queries._run_fts(
+                conn,
+                """
+                SELECT p.status_typo
+                FROM papers_fts
+                JOIN papers p ON p.id = papers_fts.rowid
+                WHERE papers_fts MATCH ?
+                """,
+                ["diffusion"],
+                raw=True,
+            )
+
+
 def test_proxy_auto_detection_covers_major_platforms(monkeypatch) -> None:
     """codex round-4 P3: auto-detect should fire for Railway, HF Spaces,
     Fly, Render, Vercel, Cloud Run, Azure App Service."""
@@ -361,6 +386,37 @@ def test_proxy_explicit_off_overrides_auto_detection(monkeypatch) -> None:
     monkeypatch.setenv("PAPERLISTS_TRUST_PROXY", "0")
     importlib.reload(m)
     assert not m._TRUST_PROXY
+
+
+def test_client_ip_prefers_x_real_ip_when_proxy_is_trusted(monkeypatch) -> None:
+    """Railway documents X-Real-IP as the client IP header; use it before XFF
+    when proxy trust is enabled."""
+    from types import SimpleNamespace
+    from paperlists_api import main as m
+
+    monkeypatch.setattr(m, "_TRUST_PROXY", True)
+    req = SimpleNamespace(
+        headers={
+            "x-real-ip": "203.0.113.8",
+            "x-forwarded-for": "198.51.100.9, 10.0.0.1",
+        },
+        client=SimpleNamespace(host="10.0.0.2"),
+    )
+    assert m._client_ip(req) == "203.0.113.8"
+
+    req.headers.pop("x-real-ip")
+    assert m._client_ip(req) == "198.51.100.9"
+
+    monkeypatch.setattr(m, "_TRUST_PROXY", False)
+    assert m._client_ip(req) == "10.0.0.2"
+
+
+def test_search_rejects_unbounded_offset_before_querying_db() -> None:
+    from fastapi.testclient import TestClient
+    from paperlists_api import main as m
+
+    resp = TestClient(m.app).get("/v1/search", params={"q": "model", "offset": m.MAX_OFFSET + 1})
+    assert resp.status_code == 422
 
 
 def test_server_errors_dont_masquerade_as_invalid_query(tmp_path: Path) -> None:
@@ -454,3 +510,38 @@ def test_top_papers_excludes_rejected_by_default(tmp_path: Path) -> None:
         )
         titles_raw = [r["title"] for r in out_raw["results"]]
         assert titles_raw == ["Rejected but cited", "Accepted poster"]
+
+
+def test_broad_analysis_queries_raise_too_many_matches(tmp_path: Path, monkeypatch) -> None:
+    """Broad aggregation endpoints should count first and fail closed instead
+    of materializing an unbounded match set in a Railway worker."""
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [
+            {"id": f"p{i}", "title": f"learning paper {i}", "keywords": "learning", "status": "Poster"}
+            for i in range(3)
+        ],
+    )
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+    monkeypatch.setattr(queries, "MAX_ANALYSIS_MATCHES", 2)
+
+    with _connect(db_path) as conn:
+        with pytest.raises(queries.TooManyMatchesError) as evolution_err:
+            queries.topic_evolution(conn, q="learning", year_from=2025, year_to=2025)
+        assert evolution_err.value.endpoint == "topic_evolution"
+        assert evolution_err.value.matches == 3
+        assert evolution_err.value.max_matches == 2
+
+        with pytest.raises(queries.TooManyMatchesError) as compare_err:
+            queries.compare_periods(
+                conn,
+                q="learning",
+                period_a=(2024, 2024),
+                period_b=(2025, 2025),
+            )
+        assert compare_err.value.endpoint == "compare_periods"
+
+        with pytest.raises(queries.TooManyMatchesError) as landscape_err:
+            queries.field_landscape(conn, q="learning", year=2025)
+        assert landscape_err.value.endpoint == "field_landscape"

--- a/tools/query-api/tests/test_indexer.py
+++ b/tools/query-api/tests/test_indexer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from paperlists_api.indexer import build_index, discover_files
+
+
+def _write_json(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(rows), encoding="utf-8")
+
+
+def test_discover_files_does_not_require_hardcoded_conference_list(tmp_path: Path) -> None:
+    _write_json(tmp_path / "newconf" / "newconf2026.json", [{"id": "a", "title": "A"}])
+    _write_json(tmp_path / "tools" / "tools2026.json", [{"id": "ignored", "title": "Ignored"}])
+
+    assert discover_files(tmp_path) == [("newconf", 2026, tmp_path / "newconf" / "newconf2026.json")]
+
+
+def test_build_index_preserves_records_without_id_field(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "siggraph" / "siggraph2024.json",
+        [
+            {"psid": "sess1", "doi": "10.1145/one", "title": "Paper One", "author": "Ada Lovelace", "keywords": "graphics"},
+            {"doi": "10.1145/example", "title": "Paper Two", "author": "Grace Hopper", "keywords": "rendering"},
+            {"psid": "sess1", "url_paper": "https://example.test/paper3", "title": "Paper Three", "author": "Alan Turing", "keywords": "simulation"},
+            {"psid": "sess1", "title": "Paper Four", "author": "Katherine Johnson", "keywords": "simulation"},
+        ],
+    )
+
+    db_path = tmp_path / "papers.db"
+    stats = build_index(tmp_path, db_path, force=True)
+
+    assert stats["rows_indexed"] == 4
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT paper_id, source_path, source_index FROM papers ORDER BY source_index"
+    ).fetchall()
+    conn.close()
+
+    assert rows[0] == ("10.1145/one", "siggraph/siggraph2024.json", 0)
+    assert rows[1] == ("10.1145/example", "siggraph/siggraph2024.json", 1)
+    assert rows[2] == ("https://example.test/paper3", "siggraph/siggraph2024.json", 2)
+    assert rows[3][0].startswith("generated:")
+    assert rows[3][1:] == ("siggraph/siggraph2024.json", 3)
+
+
+def test_build_index_tries_stable_alternate_ids_before_dedup_hash(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "siggraph" / "siggraph2025.json",
+        [
+            {"id": "shared-session", "doi": "10.1145/first", "title": "Paper One"},
+            {"id": "shared-session", "doi": "10.1145/second", "title": "Paper Two"},
+            {"id": "shared-session", "openreview": "https://openreview.net/forum?id=third", "title": "Paper Three"},
+        ],
+    )
+
+    db_path = tmp_path / "papers.db"
+    stats = build_index(tmp_path, db_path, force=True)
+
+    assert stats["rows_indexed"] == 3
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT paper_id FROM papers ORDER BY source_index").fetchall()
+    conn.close()
+
+    assert [row[0] for row in rows] == [
+        "shared-session",
+        "10.1145/second",
+        "https://openreview.net/forum?id=third",
+    ]

--- a/tools/query-api/tests/test_indexer.py
+++ b/tools/query-api/tests/test_indexer.py
@@ -70,3 +70,16 @@ def test_build_index_tries_stable_alternate_ids_before_dedup_hash(tmp_path: Path
         "10.1145/second",
         "https://openreview.net/forum?id=third",
     ]
+
+
+def test_build_index_checkpoints_wal_before_close(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "a", "title": "A", "keywords": "reasoning"}],
+    )
+
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    wal_path = Path(f"{db_path}-wal")
+    assert not wal_path.exists() or wal_path.stat().st_size == 0

--- a/tools/query-api/tests/test_query_filters.py
+++ b/tools/query-api/tests/test_query_filters.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from paperlists_api import queries
+from paperlists_api.indexer import build_index
+
+
+def _write_json(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(rows), encoding="utf-8")
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_research_endpoints_share_default_rejected_filter(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "iclr" / "iclr2024.json",
+        [
+            {
+                "id": "accepted-2024",
+                "title": "LLM reasoning accepted 2024",
+                "author": "Ada Lovelace",
+                "aff": "Example University",
+                "keywords": "llm reasoning; chain-of-thought",
+                "status": "Poster",
+            },
+            {
+                "id": "rejected-2024",
+                "title": "LLM reasoning rejected 2024",
+                "author": "Grace Hopper",
+                "aff": "Example Lab",
+                "keywords": "llm reasoning; rejected",
+                "status": "reject",
+            },
+        ],
+    )
+    _write_json(
+        tmp_path / "nips" / "nips2025.json",
+        [
+            {
+                "id": "accepted-2025",
+                "title": "LLM reasoning accepted 2025",
+                "author": "Katherine Johnson",
+                "aff": "Example University",
+                "keywords": "llm reasoning; test-time scaling",
+                "status": "Poster",
+            },
+            {
+                "id": "withdrawn-2025",
+                "title": "LLM reasoning withdrawn 2025",
+                "author": "Alan Turing",
+                "aff": "Example Lab",
+                "keywords": "llm reasoning; withdrawn",
+                "status": "WITHDRAWN",
+            },
+        ],
+    )
+
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        search_2025 = queries.search_papers(
+            conn, q="LLM reasoning", year_from=2025, year_to=2025
+        )
+        trend = queries.topic_trend(conn, q="LLM reasoning", year_from=2024, year_to=2025)
+        evolution = queries.topic_evolution(conn, q="LLM reasoning", year_from=2024, year_to=2025)
+        landscape = queries.field_landscape(conn, q="LLM reasoning", year=2025)
+        diff = queries.compare_periods(
+            conn,
+            q="LLM reasoning",
+            period_a=(2024, 2024),
+            period_b=(2025, 2025),
+        )
+
+        assert search_2025["total"] == 1
+        assert [row["papers"] for row in trend["series"]] == [1, 1]
+        assert [window["n_papers"] for window in evolution["windows"]] == [1, 1]
+        assert landscape["n_papers"] == 1
+        assert diff["period_a"]["n_papers"] == 1
+        assert diff["period_b"]["n_papers"] == 1
+
+        full_evolution = queries.topic_evolution(
+            conn,
+            q="LLM reasoning",
+            year_from=2024,
+            year_to=2025,
+            exclude_rejected=False,
+        )
+        full_landscape = queries.field_landscape(
+            conn, q="LLM reasoning", year=2025, exclude_rejected=False
+        )
+        full_diff = queries.compare_periods(
+            conn,
+            q="LLM reasoning",
+            period_a=(2024, 2024),
+            period_b=(2025, 2025),
+            exclude_rejected=False,
+        )
+
+        assert [window["n_papers"] for window in full_evolution["windows"]] == [2, 2]
+        assert full_landscape["n_papers"] == 2
+        assert full_diff["period_a"]["n_papers"] == 2
+        assert full_diff["period_b"]["n_papers"] == 2
+
+
+def test_landscape_and_period_diff_support_conference_filter(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "iclr" / "iclr2025.json",
+        [{"id": "iclr", "title": "LLM reasoning", "keywords": "llm reasoning", "status": "Poster"}],
+    )
+    _write_json(
+        tmp_path / "nips" / "nips2025.json",
+        [{"id": "nips", "title": "LLM reasoning", "keywords": "llm reasoning", "status": "Poster"}],
+    )
+
+    db_path = tmp_path / "papers.db"
+    build_index(tmp_path, db_path, force=True)
+
+    with _connect(db_path) as conn:
+        landscape = queries.field_landscape(
+            conn, q="LLM reasoning", year=2025, conferences=["iclr"]
+        )
+        diff = queries.compare_periods(
+            conn,
+            q="LLM reasoning",
+            period_a=(2025, 2025),
+            period_b=(2025, 2025),
+            conferences=["nips"],
+        )
+
+    assert landscape["n_papers"] == 1
+    assert landscape["venue_distribution"] == [("iclr", 1)]
+    assert diff["period_a"]["n_papers"] == 1
+    assert diff["period_b"]["n_papers"] == 1

--- a/tools/skill/paperlists.md
+++ b/tools/skill/paperlists.md
@@ -2,7 +2,7 @@
 name: paperlists
 description: |
   Search and analyze how AI research has evolved over time, using the
-  papercopilot/paperlists corpus (236k papers across 30 conferences,
+  papercopilot/paperlists corpus (237k+ papers across 30 conferences,
   2010-present). First-class verbs are trend-focused — topic_trend,
   topic_evolution, compare_periods, author_trajectory, field_landscape —
   not just keyword search. Backed by a hosted HTTPS API; no local data
@@ -44,7 +44,7 @@ Weak fit (other tools are better):
 ## How it works
 
 The skill is backed by a hosted HTTPS API at
-**`$PAPERLISTS_API_URL`** (default: `https://paperlists.up.railway.app`).
+**`$PAPERLISTS_API_URL`** (default: `https://api-production-18d3.up.railway.app`).
 You can call it three ways:
 
 1. **MCP** — if `paperlists-mcp` is registered with your host, just use
@@ -52,6 +52,24 @@ You can call it three ways:
 2. **HTTP via the bundled script** — `scripts/paperlists.py <endpoint> [k=v ...]`.
    Use when MCP isn't configured.
 3. **Direct curl** — for one-off ad-hoc queries.
+
+For fully local/offline runs, start the query API against a local sqlite index
+and point this skill at it:
+
+```bash
+cd tools/query-api
+python -m paperlists_api.indexer ../.. ./papers.db
+PAPERLISTS_DB=$PWD/papers.db uvicorn paperlists_api.main:app --port 8000
+```
+
+Then call the same script or MCP server with:
+
+```bash
+cd ../skill
+PAPERLISTS_API_URL=http://127.0.0.1:8000 python3 scripts/paperlists.py coverage
+```
+
+The output contract is identical between Railway-hosted and local sqlite modes.
 
 ## Tools / endpoints
 
@@ -69,14 +87,32 @@ You can call it three ways:
 | `top_papers` | `GET /v1/top_papers/{conf}/{year}` | Ranked by citation or rating |
 
 Common params: `q` (query), `conferences` (comma list like `iclr,nips,icml`),
-`year_from`/`year_to`. Abstracts are off by default to control egress —
-pass `include_abstract=true` only if you need the full text.
+`year_from`/`year_to`, and `exclude_rejected` (default `true` for **all** search,
+trend, AND ranking endpoints — including `top_papers`). Pass
+`exclude_rejected=false` only when you explicitly want raw corpus diagnostics
+that include Reject / Withdraw entries. Abstracts are off by default to control
+egress — pass `include_abstract=true` only if you need the full text.
+
+### Response shape notes
+
+- `search_papers` returns `{total_matches, returned, offset, limit, has_more, results, ...}`.
+  Use `has_more` and `offset` to paginate; never assume `results` is exhaustive.
+  (`total` is kept as a back-compat alias for one release; prefer `total_matches`.)
+- `compare_periods` returns each period as `{years: [a, b], year_from, year_to, n_papers}`
+  — both shapes are populated, pick whichever is more ergonomic.
+- `topic_evolution` adds `ranking_basis` to each window: `"gs_citation"` when
+  citations are meaningful, `"rating_avg+status_fallback"` for the current year
+  where citations are near-zero. Treat landmark order as a heuristic in the
+  fallback regime.
+- Bad FTS5 input (unbalanced quotes, raw operators) returns HTTP 400 with
+  `{error: "invalid_query"}`. The MCP/skill wrappers turn this into a normal
+  result object so agents can retry with a cleaner query.
 
 ## Worked patterns
 
 ### Pattern 1 — Research evolution in one shot
 ```bash
-scripts/paperlists.py topic_evolution q="retrieval augmented generation" year_from=2020 year_to=2025 window=1
+scripts/paperlists.py topic_evolution q="retrieval augmented generation" year_from=2020 year_to=2025 window=1 conferences=iclr,nips,icml,acl,emnlp
 ```
 Returns per-year top keywords (e.g. dense passage → llm → multi-hop),
 top venues (emnlp → iclr/nips), and landmark cited papers each year.
@@ -84,7 +120,7 @@ top venues (emnlp → iclr/nips), and landmark cited papers each year.
 
 ### Pattern 2 — Topic drift between two eras
 ```bash
-scripts/paperlists.py compare_periods q="vision transformer" period_a_from=2018 period_a_to=2020 period_b_from=2022 period_b_to=2024
+scripts/paperlists.py compare_periods q="vision transformer" period_a_from=2018 period_a_to=2020 period_b_from=2022 period_b_to=2024 conferences=iclr,nips,icml
 ```
 Returns `emerged` / `faded` / `sustained` for keywords, authors, and
 affiliations. Great for "what's new" or "what's been abandoned" narratives.
@@ -111,8 +147,12 @@ Use the canonical name as it appears on publications.
   wants temporal analysis — one call gives you the structured story.
 - **Set `limit` aggressively low** (5–10) on exploratory `search_papers`
   calls; raise it only after the user confirms direction.
-- **Hyphens and stop-words are handled** server-side ("in-context learning"
-  works; FTS5 syntax like `"exact phrase"` and `term1 OR term2` works too).
+- **Default sanitizer**: hyphens and stop-words are handled server-side
+  ("in-context learning" works). Operators (`OR`, `NOT`, `NEAR`), prefix
+  (`reason*`), column filters (`title:diffusion`), and exact phrases
+  (`"step by step"`) are **NOT** parsed in the default mode — input is
+  split into terms and AND'd. Pass `raw=true` on the endpoint when you
+  need full FTS5 syntax (malformed expressions then return HTTP 400).
 
 ## Bundled script
 

--- a/tools/skill/paperlists.md
+++ b/tools/skill/paperlists.md
@@ -1,0 +1,120 @@
+---
+name: paperlists
+description: |
+  Search and analyze how AI research has evolved over time, using the
+  papercopilot/paperlists corpus (236k papers across 30 conferences,
+  2010-present). First-class verbs are trend-focused — topic_trend,
+  topic_evolution, compare_periods, author_trajectory, field_landscape —
+  not just keyword search. Backed by a hosted HTTPS API; no local data
+  download required.
+triggers:
+  - "how has <topic> evolved"
+  - "trend of <topic> over years"
+  - "papers on <topic> in <conference>"
+  - "who is publishing on <topic>"
+  - "compare <topic> between <year_a> and <year_b>"
+  - "state of <field> in <year>"
+  - "top papers at <conference> <year>"
+  - "rating distribution of <conference>"
+  - "research evolution"
+  - "literature survey"
+---
+
+# Paperlists — AI research evolution tracker
+
+Use this skill whenever the user asks how a research area has changed
+over time, who publishes in a field, what landmark papers exist in a
+venue/year, or wants to do **literature-survey-style analysis** without
+clicking through papercopilot.com / OpenReview manually.
+
+## When to use
+
+Strong fit:
+- "How has retrieval-augmented generation evolved 2020–2025?"
+- "Compare mixture-of-experts research between 2019–2021 and 2022–2024."
+- "Top-cited diffusion model papers at NeurIPS 2023."
+- "Yann LeCun's papers since 2020."
+- "State of mechanistic interpretability in 2024."
+
+Weak fit (other tools are better):
+- A single paper lookup by exact title → just google it.
+- Live ArXiv preprints → this corpus is conference-published only.
+- Full-text PDF reading → fetch the `pdf` URL separately.
+
+## How it works
+
+The skill is backed by a hosted HTTPS API at
+**`$PAPERLISTS_API_URL`** (default: `https://paperlists.up.railway.app`).
+You can call it three ways:
+
+1. **MCP** — if `paperlists-mcp` is registered with your host, just use
+   the tool names below. Prefer this when available.
+2. **HTTP via the bundled script** — `scripts/paperlists.py <endpoint> [k=v ...]`.
+   Use when MCP isn't configured.
+3. **Direct curl** — for one-off ad-hoc queries.
+
+## Tools / endpoints
+
+| Tool | Endpoint | Purpose |
+|---|---|---|
+| `list_coverage` | `GET /v1/coverage` | What's indexed — call first if uncertain |
+| `search_papers` | `GET /v1/search` | FTS5 search over title/abstract/keywords/authors |
+| `get_paper` | `GET /v1/paper/{conf}/{paper_id}` | Single paper full record |
+| `topic_trend` | `GET /v1/topic_trend` | Yearly volume + citation-weight for a query |
+| `topic_evolution` | `GET /v1/topic_evolution` | Per-window top keywords, venues, landmark papers |
+| `compare_periods` | `GET /v1/compare_periods` | Diff a topic across two year ranges |
+| `author_trajectory` | `GET /v1/author_trajectory` | Researcher's papers grouped by year |
+| `field_landscape` | `GET /v1/field_landscape` | Single-year snapshot of a field |
+| `conference_stats` | `GET /v1/conference_stats/{conf}/{year}` | Acceptance + rating/citation summary |
+| `top_papers` | `GET /v1/top_papers/{conf}/{year}` | Ranked by citation or rating |
+
+Common params: `q` (query), `conferences` (comma list like `iclr,nips,icml`),
+`year_from`/`year_to`. Abstracts are off by default to control egress —
+pass `include_abstract=true` only if you need the full text.
+
+## Worked patterns
+
+### Pattern 1 — Research evolution in one shot
+```bash
+scripts/paperlists.py topic_evolution q="retrieval augmented generation" year_from=2020 year_to=2025 window=1
+```
+Returns per-year top keywords (e.g. dense passage → llm → multi-hop),
+top venues (emnlp → iclr/nips), and landmark cited papers each year.
+**This is usually the single best call** for "how did <field> evolve" questions.
+
+### Pattern 2 — Topic drift between two eras
+```bash
+scripts/paperlists.py compare_periods q="vision transformer" period_a_from=2018 period_a_to=2020 period_b_from=2022 period_b_to=2024
+```
+Returns `emerged` / `faded` / `sustained` for keywords, authors, and
+affiliations. Great for "what's new" or "what's been abandoned" narratives.
+
+### Pattern 3 — Surveying a venue-year
+```bash
+scripts/paperlists.py top_papers conf=nips year=2023 by=gs_citation top_k=20
+scripts/paperlists.py conference_stats conf=iclr year=2024
+```
+
+### Pattern 4 — Author-centric
+```bash
+scripts/paperlists.py author_trajectory name="Yann LeCun" year_from=2020
+```
+Use the canonical name as it appears on publications.
+
+## Efficiency tips for agents
+
+- **Always `list_coverage` first** if you're unsure whether a venue/year is
+  available. It's free and saves wasted calls.
+- **Don't fetch abstracts unless you need them.** `include_abstract=true`
+  multiplies response size ~30×.
+- **Prefer `topic_evolution` over many `search_papers` calls** when the user
+  wants temporal analysis — one call gives you the structured story.
+- **Set `limit` aggressively low** (5–10) on exploratory `search_papers`
+  calls; raise it only after the user confirms direction.
+- **Hyphens and stop-words are handled** server-side ("in-context learning"
+  works; FTS5 syntax like `"exact phrase"` and `term1 OR term2` works too).
+
+## Bundled script
+
+`scripts/paperlists.py` is a minimal Python CLI that talks to the same API
+the MCP server uses. Useful when MCP isn't available. See `scripts/paperlists.py --help`.

--- a/tools/skill/paperlists.md
+++ b/tools/skill/paperlists.md
@@ -2,7 +2,7 @@
 name: paperlists
 description: |
   Search and analyze how AI research has evolved over time, using the
-  papercopilot/paperlists corpus (237k+ papers across 30 conferences,
+  papercopilot/paperlists corpus (237k+ papers across 31 venues,
   2010-present). First-class verbs are trend-focused — topic_trend,
   topic_evolution, compare_periods, author_trajectory, field_landscape —
   not just keyword search. Backed by a hosted HTTPS API; no local data
@@ -44,7 +44,9 @@ Weak fit (other tools are better):
 ## How it works
 
 The skill is backed by a hosted HTTPS API at
-**`$PAPERLISTS_API_URL`** (default: `https://api-production-18d3.up.railway.app`).
+**`$PAPERLISTS_API_URL`**. For demo testing only, use
+`https://api-production-18d3.up.railway.app`; production releases should point
+at papercopilot-owned or self-hosted infrastructure.
 You can call it three ways:
 
 1. **MCP** — if `paperlists-mcp` is registered with your host, just use
@@ -98,6 +100,7 @@ egress — pass `include_abstract=true` only if you need the full text.
 - `search_papers` returns `{total_matches, returned, offset, limit, has_more, results, ...}`.
   Use `has_more` and `offset` to paginate; never assume `results` is exhaustive.
   (`total` is kept as a back-compat alias for one release; prefer `total_matches`.)
+  The hosted API caps `offset` at 10k to avoid expensive deep pagination.
 - `compare_periods` returns each period as `{years: [a, b], year_from, year_to, n_papers}`
   — both shapes are populated, pick whichever is more ergonomic.
 - `topic_evolution` adds `ranking_basis` to each window: `"gs_citation"` when
@@ -107,6 +110,8 @@ egress — pass `include_abstract=true` only if you need the full text.
 - Bad FTS5 input (unbalanced quotes, raw operators) returns HTTP 400 with
   `{error: "invalid_query"}`. The MCP/skill wrappers turn this into a normal
   result object so agents can retry with a cleaner query.
+- Overly broad analysis calls return HTTP 400 with `{error: "too_many_matches"}`.
+  Narrow the year range, venues, or query before retrying.
 
 ## Worked patterns
 

--- a/tools/skill/scripts/paperlists.py
+++ b/tools/skill/scripts/paperlists.py
@@ -10,16 +10,23 @@ Usage:
 Examples:
     paperlists.py coverage
     paperlists.py search q="diffusion model" year_from=2022 limit=10
+    paperlists.py search q='title:diffusion AND NOT survey' raw=true limit=10
     paperlists.py topic_trend q="rlhf" year_from=2020 year_to=2025
-    paperlists.py topic_evolution q="retrieval augmented" year_from=2020 year_to=2025 window=1
-    paperlists.py compare_periods q="moe" period_a_from=2018 period_a_to=2020 period_b_from=2022 period_b_to=2024
-    paperlists.py field_landscape q="mechanistic interpretability" year=2024
+    paperlists.py topic_evolution q="retrieval augmented" year_from=2020 year_to=2025 window=1 conferences=iclr,nips,icml
+    paperlists.py compare_periods q="moe" period_a_from=2018 period_a_to=2020 period_b_from=2022 period_b_to=2024 exclude_rejected=false
+    paperlists.py field_landscape q="mechanistic interpretability" year=2024 conferences=iclr,nips,icml
     paperlists.py author_trajectory name="Yann LeCun" year_from=2020
     paperlists.py paper conf=iclr paper_id=00SnKBGTsz
     paperlists.py conference_stats conf=iclr year=2024
     paperlists.py top_papers conf=nips year=2023 by=gs_citation top_k=10
 
-Env: PAPERLISTS_API_URL (default https://paperlists.up.railway.app)
+Notes on `q=` queries:
+    By default, input is split into terms and AND'd. To use FTS5 operators
+    (`OR`, `NEAR`, prefix `*`, column filters like `title:foo`, exact
+    phrases), append `raw=true`. Bad raw queries return HTTP 400 with
+    {"error":"invalid_query"}.
+
+Env: PAPERLISTS_API_URL (default https://api-production-18d3.up.railway.app)
 Dependencies: only stdlib (no requests/httpx required).
 """
 from __future__ import annotations
@@ -30,7 +37,7 @@ import sys
 import urllib.parse
 import urllib.request
 
-API_URL = os.environ.get("PAPERLISTS_API_URL", "https://paperlists.up.railway.app").rstrip("/")
+API_URL = os.environ.get("PAPERLISTS_API_URL", "https://api-production-18d3.up.railway.app").rstrip("/")
 
 # Maps the CLI verb to (path_template, list_of_url_args).
 # Path args are pulled out of kwargs; the rest become querystring.
@@ -70,7 +77,7 @@ def main(argv: list[str]) -> int:
     kv = _parse_kv(argv[2:])
 
     try:
-        path = path_tpl.format(**{k: kv.pop(k) for k in path_args})
+        path = path_tpl.format(**{k: urllib.parse.quote(kv.pop(k), safe="") for k in path_args})
     except KeyError as e:
         print(f"missing required path arg: {e.args[0]}", file=sys.stderr)
         return 2

--- a/tools/skill/scripts/paperlists.py
+++ b/tools/skill/scripts/paperlists.py
@@ -26,7 +26,7 @@ Notes on `q=` queries:
     phrases), append `raw=true`. Bad raw queries return HTTP 400 with
     {"error":"invalid_query"}.
 
-Env: PAPERLISTS_API_URL (default https://api-production-18d3.up.railway.app)
+Env: PAPERLISTS_API_URL (required; demo https://api-production-18d3.up.railway.app)
 Dependencies: only stdlib (no requests/httpx required).
 """
 from __future__ import annotations
@@ -37,7 +37,8 @@ import sys
 import urllib.parse
 import urllib.request
 
-API_URL = os.environ.get("PAPERLISTS_API_URL", "https://api-production-18d3.up.railway.app").rstrip("/")
+DEMO_API_URL = "https://api-production-18d3.up.railway.app"
+API_URL = os.environ.get("PAPERLISTS_API_URL", "").rstrip("/")
 
 # Maps the CLI verb to (path_template, list_of_url_args).
 # Path args are pulled out of kwargs; the rest become querystring.
@@ -72,6 +73,13 @@ def main(argv: list[str]) -> int:
     verb = argv[1]
     if verb not in ENDPOINTS:
         print(f"unknown endpoint {verb!r}. Available: {', '.join(ENDPOINTS)}", file=sys.stderr)
+        return 2
+    if not API_URL:
+        print(
+            "PAPERLISTS_API_URL is required. For demo testing only, set "
+            f"PAPERLISTS_API_URL={DEMO_API_URL}",
+            file=sys.stderr,
+        )
         return 2
     path_tpl, path_args = ENDPOINTS[verb]
     kv = _parse_kv(argv[2:])

--- a/tools/skill/scripts/paperlists.py
+++ b/tools/skill/scripts/paperlists.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Bundled CLI client for the paperlists hosted API.
+
+Used by the paperlists skill when MCP isn't configured. Calls the same
+endpoints as paperlists-mcp.
+
+Usage:
+    paperlists.py <endpoint> [key=value ...]
+
+Examples:
+    paperlists.py coverage
+    paperlists.py search q="diffusion model" year_from=2022 limit=10
+    paperlists.py topic_trend q="rlhf" year_from=2020 year_to=2025
+    paperlists.py topic_evolution q="retrieval augmented" year_from=2020 year_to=2025 window=1
+    paperlists.py compare_periods q="moe" period_a_from=2018 period_a_to=2020 period_b_from=2022 period_b_to=2024
+    paperlists.py field_landscape q="mechanistic interpretability" year=2024
+    paperlists.py author_trajectory name="Yann LeCun" year_from=2020
+    paperlists.py paper conf=iclr paper_id=00SnKBGTsz
+    paperlists.py conference_stats conf=iclr year=2024
+    paperlists.py top_papers conf=nips year=2023 by=gs_citation top_k=10
+
+Env: PAPERLISTS_API_URL (default https://paperlists.up.railway.app)
+Dependencies: only stdlib (no requests/httpx required).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+API_URL = os.environ.get("PAPERLISTS_API_URL", "https://paperlists.up.railway.app").rstrip("/")
+
+# Maps the CLI verb to (path_template, list_of_url_args).
+# Path args are pulled out of kwargs; the rest become querystring.
+ENDPOINTS = {
+    "coverage":            ("/v1/coverage", []),
+    "search":              ("/v1/search", []),
+    "paper":               ("/v1/paper/{conf}/{paper_id}", ["conf", "paper_id"]),
+    "topic_trend":         ("/v1/topic_trend", []),
+    "topic_evolution":     ("/v1/topic_evolution", []),
+    "compare_periods":     ("/v1/compare_periods", []),
+    "author_trajectory":   ("/v1/author_trajectory", []),
+    "field_landscape":     ("/v1/field_landscape", []),
+    "conference_stats":    ("/v1/conference_stats/{conf}/{year}", ["conf", "year"]),
+    "top_papers":          ("/v1/top_papers/{conf}/{year}", ["conf", "year"]),
+}
+
+
+def _parse_kv(args: list[str]) -> dict:
+    out: dict[str, str] = {}
+    for a in args:
+        if "=" not in a:
+            raise SystemExit(f"bad argument {a!r}; expected key=value")
+        k, _, v = a.partition("=")
+        out[k.strip()] = v.strip()
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or argv[1] in ("-h", "--help"):
+        print(__doc__)
+        return 0
+    verb = argv[1]
+    if verb not in ENDPOINTS:
+        print(f"unknown endpoint {verb!r}. Available: {', '.join(ENDPOINTS)}", file=sys.stderr)
+        return 2
+    path_tpl, path_args = ENDPOINTS[verb]
+    kv = _parse_kv(argv[2:])
+
+    try:
+        path = path_tpl.format(**{k: kv.pop(k) for k in path_args})
+    except KeyError as e:
+        print(f"missing required path arg: {e.args[0]}", file=sys.stderr)
+        return 2
+
+    qs = urllib.parse.urlencode(kv)
+    url = f"{API_URL}{path}" + (f"?{qs}" if qs else "")
+
+    req = urllib.request.Request(url, headers={"User-Agent": "paperlists-skill/0.1"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        body = e.read()
+        print(f"HTTP {e.code} from {url}", file=sys.stderr)
+        print(body.decode("utf-8", "replace"), file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        parsed = json.loads(body)
+        json.dump(parsed, sys.stdout, indent=2, ensure_ascii=False)
+        print()
+    except json.JSONDecodeError:
+        sys.stdout.write(body.decode("utf-8", "replace"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
# Proposal + implementation: a longitudinal research-vision layer over paperlists

Hi @jingyangcarl 👋 — long time no see. I'm the contributor of #7 (the Streamlit local search tool). Two quick threads before the proposal:

1. Thank you again for the back-and-forth during my junior research days — that conversation shaped how I think about open data infra.
2. Since then I've started a few research projects of my own, and this dataset has been the single most useful conference-paper resource I keep coming back to. The cross-venue, multi-year, review-score coverage is genuinely hard to find elsewhere.

## What this is — and what it deliberately is NOT

The agent/AI tooling around papers has stratified into 3 mature niches. There's a 4th one that nothing on the market actually fills, and that's what `paperlists`' decade-deep, multi-venue corpus is uniquely positioned to do.

| Tool | What it answers | Granularity | Time axis |
|---|---|---|---|
| **papercopilot.com** | "How selective was ICLR 2024? What's the rating distribution?" | Venue × year aggregates | snapshot |
| **alphaxiv** / similar | "Explain this paper. Find similar ones. Q&A on the abstract." | Single paper | none |
| **hf paper-cli** / arxiv search | "Read / summarize / download this PDF." | Single paper | none |
| **THIS PR** | **"Give me the *longitudinal vision* on a research direction."** | **Topic × time × venue × author × affiliation** | **10+ years** |

The 4th column is the actual researcher workflow nothing serves today:

- *"I'm thinking of working on mechanistic interpretability — is the field still alive? Who's pushing it? What sub-direction emerged in the last 2 years vs what saturated?"*
- *"Should I pivot from sparse-MoE to test-time scaling? What's the trajectory? Who am I going to compete with?"*
- *"Has retrieval-augmented generation actually evolved between 2020 and 2025, or is it just renamed dense passage retrieval?"*
- *"Where did process reward modeling come from, and who are the labs that converged on it?"*

These are the questions a researcher actually asks before committing 6 months of their life. They are awkward on a web UI (too many clicks across years/venues), trivial for an agent if the corpus is queryable. **And the answers only exist because of the 10+ years of OpenReview review scores, citations, and affiliations you've already curated.** No other open dataset has this depth.

## What's in this PR

A three-tier additive architecture, all under `tools/`. Nothing outside `tools/` is touched (zero changes to the data layout):

```
tools/
  query-api/      FastAPI + sqlite FTS5 service (Railway/HF Spaces deployable)
  mcp-server/     Thin MCP wrapper (~5 MB install) — Claude Code / Cursor / Codex / any MCP host
  skill/          Cross-tool Skill (.md + stdlib-only Python CLI) for hosts that load skills directly
```

### Endpoints — the *longitudinal* verbs are first-class

| Endpoint | The researcher question it answers |
|---|---|
| `GET /v1/topic_evolution` | **"How did <topic> drift between year X and year Y?"** — per-window top co-occurring keywords + landmark papers, with `ranking_basis` switching between citation (for old work) and rating+status (for current year) |
| `GET /v1/compare_periods` | **"What emerged / faded / sustained in <topic> between two eras?"** — diffs on keywords, authors, and affiliations across two year ranges |
| `GET /v1/topic_trend` | **"Is <field> growing or dying?"** — yearly volume + citation-weighted volume, broken down by venue |
| `GET /v1/field_landscape` | **"State of <field> in <year>"** — top papers, authors, affiliations, keywords in one snapshot |
| `GET /v1/author_trajectory` | **"What is <researcher> working on now vs 5 years ago?"** — papers grouped by year |
| `GET /v1/conference_stats/{conf}/{year}` | acceptance breakdown + rating/citation summary |
| `GET /v1/top_papers/{conf}/{year}` | ranked by citation or rating, with `exclude_rejected=true` by default |
| `GET /v1/search` | standard FTS5 search (sanitized by default; `raw=true` for power users) |
| `GET /v1/paper/{conf}/{paper_id}` | single record (full schema, including abstract) |
| `GET /v1/coverage` | self-describing — what venues/years are indexed |

The MCP server exposes the same surface as 10 tools. Tool descriptions explicitly steer agents toward `topic_evolution` / `compare_periods` when the user asks evolution-shaped questions, so the agent's first instinct on "how has X changed" is a single trend call rather than 20 `search` calls.

## Hardened, tested, and live

- **Hosted demo** (community-run, MIT-licensed, no auth): `https://api-production-18d3.up.railway.app` ([docs](https://api-production-18d3.up.railway.app/docs))
- **Corpus indexed**: 237,735 papers across 31 conferences, ~623 MB sqlite FTS5, built nightly in the Docker builder from a fresh GitHub tarball (no committed DB)
- **Tests**: 37 passing, including parametrized FTS5 fuzz (raw-mode malformed input → 400) + cross-worker rate-limit persistence + landmark-fallback sort key + indexer dedup recovering 314 silently-dropped SIGGRAPH/ICLR papers
- **Production guards** (Round 1-5 of codex review hardening):
  - Rate limiter is **sqlite-backed across workers** (separate writable file), so 4-worker Railway deployments share one bucket per IP
  - `PAPERLISTS_TRUST_PROXY` defaults to `"auto"` and auto-detects Railway / HF Spaces / Fly / Render / Vercel / Cloud Run / Azure App Service env markers; explicit `0`/`1` overrides
  - FTS5 sanitizer wraps each token in double quotes so user input can't trigger 500s; `raw=true` opts back in to full FTS5 syntax with HTTP 400 on parse errors
  - `topic_evolution` and `compare_periods` cap at 50k matched rows with `too_many_matches` HTTP 400 so a runaway query can't OOM a worker
  - Egress controls: `include_abstract` defaults to `false`; cards exclude `bibtex`/`reviewers`/`or_profile`; deep pagination capped at `offset=10k`
  - WAL-checkpointed single-file `papers.db` in the Docker runtime image; immutable read-only opens in production

## Worked examples (all real, against the live demo)

```bash
# "Has reasoning research actually shifted between 2024 and 2025?"
topic_evolution q="LLM reasoning" year_from=2024 year_to=2025 window=1 \
  conferences=iclr,nips,icml,acl,emnlp
# → emerged keyword: "reinforcement learning" goes from 7 → 100 mentions (×14)
# → landmark drift: "Let's Verify Step by Step" (2024) → "WizardMath" + "GSM-Symbolic" (2025)
# → venue mix flips: 2024 EMNLP-dominant → 2025 ACL≈NeurIPS at top

# "Vision transformer drift between 2018-2020 and 2022-2024"
compare_periods q="vision transformer" period_a_from=2018 period_a_to=2020 \
  period_b_from=2022 period_b_to=2024 conferences=iclr,nips,icml
# → 111 → 2112 papers; emerged keywords include "ViT", "multimodal";
# → emerged affiliations: Shanghai AI Lab, Meta FAIR;
# → faded: legacy CNN-comparison subjects

# "Who's pushing reasoning research and where are they now?"
author_trajectory name="Yejin Choi" year_from=2020
# → year-by-year paper list with venues + citations
```

## Deployment plan (egress + sustainability)

**Hosting**: I'm running the demo on **Railway** under my account (env-var-driven; no secrets in the repo). The MCP/Skill scripts require an explicit `PAPERLISTS_API_URL` — the demo URL is documented as demo-only, never as a hardcoded default — so nothing accidentally hammers my Railway instance from a forked install. If you'd rather it live on `papercopilot` infra (Railway, HF Spaces under the `papercopilot` org, your own server), happy to migrate or co-administer with zero strings attached.

**Cost envelope**: free hobby tier (~$5/mo credit) handles the current demo load. If it grows, the same Dockerfile redeploys to Cloudflare Workers + D1 (near-zero idle cost) or HF Spaces (free, ML-community-native) with no code changes — only the DB driver.

## What's intentionally NOT in this PR

- No changes to existing data layout (still your `<conf>/<conf><year>.json` layout)
- No removal of `app.py` or `extract.py` — the Streamlit tool stays
- No embedding-based / semantic search — deferred; would need a vector DB
- No affiliation normalization across `aff_unique_norm` variants — left for v2 (a known imperfection)

## What I'm asking before merge

Based on your earlier reply suggesting a separate repo + co-management, my proposed concrete handoff:

1. **You create** `papercopilot/paperlists-agent` (or your preferred name) and add me as a maintainer
2. **I open** a single migration PR there (moves `tools/{query-api,mcp-server,skill}` + carries the remaining Copilot review comments + a stub `/v1/corpus_manifest` endpoint as the integration point for your agentic data-fetching pipeline)
3. **We close** this PR with a "superseded by papercopilot/paperlists-agent#1" link, so the history is preserved
4. **We sync once** on the `corpus_manifest` shape so your pipeline writes provenance/freshness and the API just serves it — clean separation, no tight coupling

Aligned with your framing: treat `paperlists-agent` as the staging ground; whatever proves out in real usage there is a candidate to flow back into papercopilot.com proper. I'll keep the API surface minimal and well-tested so it's cheap to lift pieces out.

— @hhh2210
